### PR TITLE
some fixes for packaging with python3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-linuxcnc (1:2.9.0~pre0) stretch; urgency=medium
-
-  * Master branch open for new features.
-
- -- Sebastian Kuzminsky <seb@highlab.com>  Sun, 02 Jun 2019 16:52:46 -0600
-
 linuxcnc (1:2.8.0) buster; urgency=low
 
   * Finally merge "Joints Axes". Joints and cartesian axes are no longer
@@ -125,6 +119,7 @@ linuxcnc (1:2.8.0) buster; urgency=low
  -- andypugh <andy@bodgesoc.org>  Sun, 12 Jul 2020 20:29:54 +0100
 
 linuxcnc (1:2.8.0~pre1) rosa; urgency=low
+
   * New external axis offsets
   * New support for Mesa 7i96 ethernet card
   * New experimental QT based VCP
@@ -134,6 +129,8 @@ linuxcnc (1:2.8.0~pre1) rosa; urgency=low
   * Back tool lathe support in axis and gmoccapy
   * Seperate joint and axis limits for non trivial kins machines
   * bldc_hall removed: use bldc
+
+ -- Sebastian Kuzminsky <seb@highlab.com>  Sun, 26 Oct 2014 23:18:24 -0600
 
 linuxcnc (1:2.7.15) unstable; urgency=medium
 
@@ -231,7 +228,11 @@ linuxcnc (1:2.7.15) unstable; urgency=medium
 
  -- Sebastian Kuzminsky <seb@highlab.com>  Thu, 02 Jan 2020 11:59:23 -0700
 
- -- John Thornton <jthornton@gnipsel.com>  Thu, 6 Jun 2019 14:50:43 -0500
+linuxcnc (1:2.9.0~pre0) stretch; urgency=medium
+
+  * Master branch open for new features.
+
+ -- Sebastian Kuzminsky <seb@highlab.com>  Sun, 02 Jun 2019 16:52:46 -0600
 
 linuxcnc (1:2.7.14) unstable; urgency=medium
 

--- a/debian/configure
+++ b/debian/configure
@@ -176,7 +176,7 @@ STANDARDS_VERSION="3.9.3"
 case $DISTRIB_NAME in
 Ubuntu-20.04*|Debian-testing)
         DOC_DEPENDS="$DOC_DEPENDS, asciidoc-dblatex"
-        YAPPS_RUNTIME="python3-yapps2"
+        YAPPS_RUNTIME="yapps2"
         ;;
 Debian-10|Debian-10.*|Raspbian-10|Raspbian-10.*)
         DOC_DEPENDS="$DOC_DEPENDS, asciidoc-dblatex"

--- a/debian/configure
+++ b/debian/configure
@@ -174,7 +174,7 @@ PYTHON_IMAGING_TK="python${PYTHON_VERSION}-imaging-tk | python-imaging-tk | pyth
 STANDARDS_VERSION="3.9.3"
 
 case $DISTRIB_NAME in
-Ubuntu-20.04*)
+Ubuntu-20.04*|Debian-testing)
         DOC_DEPENDS="$DOC_DEPENDS, asciidoc-dblatex"
         YAPPS_RUNTIME="python3-yapps2"
         ;;

--- a/debian/configure
+++ b/debian/configure
@@ -166,7 +166,7 @@ fi
 
 MODUTILS_DEPENDS=kmod
 PYTHON_PACKAGING_DEPENDS=dh-python
-PYTHON_PACKAGING=dh_python2
+PYTHON_PACKAGING=dh_python3
 TCLTK_VERSION=8.6
 PYTHON_IMAGING="python${PYTHON_VERSION}-imaging | python-imaging | python-pil"
 PYTHON_IMAGING_TK="python${PYTHON_VERSION}-imaging-tk | python-imaging-tk | python-pil.imagetk"

--- a/debian/control.main-pkg.in
+++ b/debian/control.main-pkg.in
@@ -5,7 +5,7 @@ Recommends: linuxcnc-doc-en | linuxcnc-doc, @EXTRA_RECOMMENDS@
 Depends: ${shlibs:Depends}, @KERNEL_DEPENDS@,
     tcl@TCLTK_VERSION@, tk@TCLTK_VERSION@, bwidget (>= 1.7), libtk-img (>=1.13),
     python3,
-    ${python:Depends}, ${misc:Depends},
+    ${python3:Depends}, ${misc:Depends},
     python@PYTHON_VERSION@-tk,
     libgladeui-dev,
     python@PYTHON_VERSION@-numpy | python-numpy,

--- a/debian/control.main-pkg.in
+++ b/debian/control.main-pkg.in
@@ -4,7 +4,7 @@ Architecture: any
 Recommends: linuxcnc-doc-en | linuxcnc-doc, @EXTRA_RECOMMENDS@
 Depends: ${shlibs:Depends}, @KERNEL_DEPENDS@,
     tcl@TCLTK_VERSION@, tk@TCLTK_VERSION@, bwidget (>= 1.7), libtk-img (>=1.13),
-    python3
+    python3,
     ${python:Depends}, ${misc:Depends},
     python@PYTHON_VERSION@-tk,
     libgladeui-dev,

--- a/debian/control.main-pkg.in
+++ b/debian/control.main-pkg.in
@@ -13,7 +13,6 @@ Depends: ${shlibs:Depends}, @KERNEL_DEPENDS@,
     @PYTHON_IMAGING_TK@,
     libgtksourceview-3.0-dev,
     python-vte | gir1.2-vte-2.91,
-    @PYTHON_GST@,
     python-xlib, python3-configobj,
     tclreadline, procps, psmisc, tclx, @MODUTILS_DEPENDS@,
     mesa-utils, blt, udev

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -45,7 +45,7 @@ Architecture: any
 Conflicts: linuxcnc-sim-dev, @OTHER_MAIN_PACKAGE_NAME@-dev
 Depends: g++, @KERNEL_HEADERS@,
     python3-serial,
-    python3
+    python3,
     ${python:Depends}, ${misc:Depends},
     @MAIN_PACKAGE_NAME@ (= ${binary:Version}),
     udev,

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -46,7 +46,7 @@ Conflicts: linuxcnc-sim-dev, @OTHER_MAIN_PACKAGE_NAME@-dev
 Depends: g++, @KERNEL_HEADERS@,
     python3-serial,
     python3,
-    ${python:Depends}, ${misc:Depends},
+    ${python3:Depends}, ${misc:Depends},
     @MAIN_PACKAGE_NAME@ (= ${binary:Version}),
     udev,
     @YAPPS_RUNTIME@

--- a/share/qtvcp/screens/qtdragon/qtdragon_handler.py
+++ b/share/qtvcp/screens/qtdragon/qtdragon_handler.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import os
 import linuxcnc
 import hal


### PR DESCRIPTION
This still fails the CI, but after it builds the *.debs.
It looks like some files hasn't been ported to python3 yet.

I added Debian-testing as a distribution mainly because that's what I'm using to test with.

Regarding the python-gst packages, are they no longer needed? They do exists as python3 packages at least from Debian Jessie and later.