### PR TITLE
halmeter: Replace deprecated functions

### DIFF
--- a/src/hal/utils/meter.c
+++ b/src/hal/utils/meter.c
@@ -1,6 +1,6 @@
 /** This file, 'meter.c', is a GUI program that serves as a simple
     meter to look at HAL signals.  It is a user space component and
-    uses GTK 1.2 for the GUI code.  It allows you to view one pin,
+    uses GTK 3 for the GUI code.  It allows you to view one pin,
     signal, or parameter, and updates its display about 10 times
     per second.  (It is not a realtime program, and heavy loading
     can temporarily slow or stop the update.)  Clicking on the 'Select'
@@ -64,7 +64,6 @@
 
 #include <gtk/gtk.h>
 #include "miscgtk.h"		/* generic GTK stuff */
-#include <gdk/gdkkeysyms.h>
 #include <rtapi_string.h>
 
 /***********************************************************************
@@ -100,6 +99,12 @@ typedef struct {
 *                  GLOBAL VARIABLES DECLARATIONS                       *
 ************************************************************************/
 
+/* Columns in the TreeView */
+enum TREEVIEW_COLUMN {
+    LIST_ITEM,
+    NUM_COLS
+};
+
 int comp_id;			/* HAL component ID */
 
 GtkWidget *main_window;
@@ -132,12 +137,10 @@ static char *data_value(int type, void *valptr);
 
 static void create_probe_window(probe_t * probe);
 static void apply_selection(GtkWidget * widget, gpointer data);
-static void close_selection(GtkWidget * widget, gpointer data);
-static gboolean key_press(GtkWidget * clist, GdkEventKey *event, gpointer user_data);
-static void selection_made(GtkWidget * clist, gint row, gint column,
-    GdkEventButton * event, gpointer data);
-static void page_switched(GtkNotebook *notebook, GtkNotebookPage *page,
-		guint page_num, gpointer user_data);
+static void page_switched(GtkNotebook *notebook, GtkWidget *page,
+                          guint page_num, gpointer user_data);
+static void on_changed(GtkWidget *widget, gpointer data);
+
 /***********************************************************************
 *                        MAIN() FUNCTION                               *
 ************************************************************************/
@@ -231,8 +234,6 @@ int main(int argc, gchar * argv[])
     signal(SIGINT, quit);
     signal(SIGTERM, quit);
 
-    /* create main window, set it's size, and lock the size */
-    main_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     /* ideally this wouldn't be fixed size in pixels */
     if ( small ) {
 	height = 22;
@@ -241,21 +242,22 @@ int main(int argc, gchar * argv[])
 	height = 80;
 	win_name = _("Hal Meter");
     }
-    gtk_widget_set_usize(GTK_WIDGET(main_window), width, height);
-    gtk_window_set_policy(GTK_WINDOW(main_window), FALSE, FALSE, FALSE);
+
+    /* create main window, set it's size, title, and lock the size */
+    main_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_widget_set_size_request(GTK_WIDGET(main_window), width, height);
+    gtk_window_set_resizable(GTK_WINDOW(main_window), FALSE);
     gtk_window_set_keep_above(GTK_WINDOW(main_window),TRUE);
-    /* set main window title */
     gtk_window_set_title(GTK_WINDOW(main_window), win_name);
+
     /* this makes the application exit when the window is closed */
-    gtk_signal_connect(GTK_OBJECT(main_window), "destroy",
-	GTK_SIGNAL_FUNC(gtk_main_quit), NULL);
+    g_signal_connect(main_window, "destroy",
+            G_CALLBACK(gtk_main_quit), NULL);
 
     /* a vbox to hold the displayed value and the pin/sig/param name */
-    vbox = gtk_vbox_new(FALSE, 3);
+    vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 3);
     gtk_container_set_border_width(GTK_CONTAINER(vbox), 2);
-    /* add the vbox to the main window */
     gtk_container_add(GTK_CONTAINER(main_window), vbox);
-    gtk_widget_show(vbox);
 
     /* create a meter object */
     meter = meter_new();
@@ -273,48 +275,41 @@ int main(int argc, gchar * argv[])
 
     /* add the meter's value label to the vbox */
     gtk_box_pack_start(GTK_BOX(vbox), meter->value_label, TRUE, TRUE, 0);
-    gtk_widget_show(meter->value_label);
 
     /* add the meter's name label to the vbox */
     if ( !small ) {
 	gtk_box_pack_start(GTK_BOX(vbox), meter->name_label, TRUE, TRUE, 0);
-	gtk_widget_show(meter->name_label);
     }
 
     /* arrange for periodic refresh of the value */
-    gtk_timeout_add(100, refresh_value, meter);
+    g_timeout_add(100, refresh_value, meter);
 
     /* an hbox to hold the select and exit buttons */
     if ( !small ) {
 	hbox = gtk_hbox_new_in_box(FALSE, 0, 0, vbox, FALSE, TRUE, 0);
 
 	/* create the buttons and add them to the hbox */
-	button_select = gtk_button_new_with_label(_("_Select"));
-	button_exit = gtk_button_new_with_label(_("E_xit"));
-	gtk_button_set_use_underline((GtkButton *)button_select, TRUE);
-	gtk_button_set_use_underline((GtkButton *)button_exit, TRUE);
+	button_select = gtk_button_new_with_mnemonic(_("_Select"));
+	button_exit = gtk_button_new_with_mnemonic(_("E_xit"));
 
 	gtk_box_pack_start(GTK_BOX(hbox), button_select, TRUE, TRUE, 4);
 	gtk_box_pack_start(GTK_BOX(hbox), button_exit, TRUE, TRUE, 4);
 
-	/* make the application exit when the 'exit' button is clicked */
-	gtk_signal_connect(GTK_OBJECT(button_exit), "clicked",
-	    GTK_SIGNAL_FUNC(gtk_main_quit), NULL);
+        /* make the application exit when the 'exit' button is clicked */
+        g_signal_connect(button_exit, "clicked",
+                G_CALLBACK(gtk_main_quit), NULL);
 
-	/* activate selection window when the 'select' button is clicked */
-	gtk_signal_connect(GTK_OBJECT(button_select), "clicked",
-	    GTK_SIGNAL_FUNC(popup_probe_window), meter->probe);
+        /* activate selection window when the 'select' button is clicked */
+        g_signal_connect(button_select, "clicked",
+                G_CALLBACK(popup_probe_window), meter->probe);
 
 	/* save reference to select button */
 	meter->button_select = button_select;
-
-	gtk_widget_show(button_select);
-	gtk_widget_show(button_exit);
     }
 
     /* The interface is now set up so we show the window and
        enter the gtk_main loop. */
-    gtk_widget_show(main_window);
+    gtk_widget_show_all(main_window);
     /* If the -g option was invoked: set position */
     if (geometryflag == 1) {
         gtk_window_move(GTK_WINDOW(main_window),xposition,yposition);
@@ -390,115 +385,95 @@ probe_t *probe_new(char *probe_name)
 void popup_probe_window(GtkWidget * widget, gpointer data)
 {
     probe_t *probe;
-    int next, row, match;
     hal_pin_t *pin;
     hal_sig_t *sig;
     hal_param_t *param;
-    gchar *name;
+
+    int next, row, match_row, tab, match_tab;
+    char *name[HAL_NAME_LEN + 1];
+
 
     /* get a pointer to the probe data structure */
     probe = (probe_t *) data;
 
     /* create window if needed */
     if (probe->window == NULL) {
-	create_probe_window(probe);
-    }else{
-    gtk_window_present(GTK_WINDOW(probe->window));
+        create_probe_window(probe);
+    } else {
+        gtk_window_present(GTK_WINDOW(probe->window));
     }
 
-    gtk_clist_clear(GTK_CLIST(probe->lists[0]));
-    gtk_clist_clear(GTK_CLIST(probe->lists[1]));
-    gtk_clist_clear(GTK_CLIST(probe->lists[2]));
+    /*
+     * This part clears the list, then add all items back into the list.
+     * If a pin, signal or paramater is showing in the main window, that item
+     * should be selected in the "Select item to probe" window, when the window
+     * is displayed again.
+     *
+     * Changing the tab (page) and selecting the item (row) needs to be done after
+     * the window is displayed.
+     */
+    clear_list(probe->lists[0]);
+    clear_list(probe->lists[1]);
+    clear_list(probe->lists[2]);
+
     rtapi_mutex_get(&(hal_data->mutex));
     next = hal_data->pin_list_ptr;
-    row = 0; match = 0;
-    gtk_clist_freeze(GTK_CLIST(probe->lists[0]));
+    match_tab = 0;
+    match_row = 0;
+    row = 0;
+    tab = 0;
     while (next != 0) {
-	pin = SHMPTR(next);
-	name = pin->name;
-	gtk_clist_append(GTK_CLIST(probe->lists[0]), &name);
+        pin = SHMPTR(next);
+        *name = pin->name;
 
-	/* if we have a pin selected, and it matches the current one,
-	   mark this row) */
-	if ((probe->listnum == 0) && (probe->pin == pin)) {
-	    gtk_clist_select_row(GTK_CLIST(probe->lists[0]), row, 0);
-	    /* Get the text from the list */
-	    gtk_clist_get_text(GTK_CLIST(probe->lists[0]), row, 0,
-		&(probe->pickname));
-	    match = 1;
-	}
-	
-	next = pin->next_ptr;
-	row++;
+        add_to_list(probe->lists[tab], name, NUM_COLS);
+        if (probe->pin == pin) {
+            match_tab = tab;
+            match_row = row;
+        }
+        next = pin->next_ptr;
+        row++;
     }
-    gtk_clist_thaw(GTK_CLIST(probe->lists[0]));
-    // if no match, unselect the first row, otherwise it will stay selected
-    // and confuse the user
-    if (!match)
-    	gtk_clist_unselect_row(GTK_CLIST(probe->lists[0]), 0, 0);
-    
+
     next = hal_data->sig_list_ptr;
-    row = 0; match = 0;
-    gtk_clist_freeze(GTK_CLIST(probe->lists[1]));
+    row = 0;
+    tab = 1;
     while (next != 0) {
-	sig = SHMPTR(next);
-	name = sig->name;
-	gtk_clist_append(GTK_CLIST(probe->lists[1]), &name);
+        sig = SHMPTR(next);
+        *name = sig->name;
 
-	/* if we have a signal selected, and it matches the current
-	   one, mark this row) */
-	if ((probe->listnum == 1) && (probe->sig == sig)) {
-	    gtk_clist_select_row(GTK_CLIST(probe->lists[1]), row, 0);
-	    /* Get the text from the list */
-	    gtk_clist_get_text(GTK_CLIST(probe->lists[1]), row, 0,
-		&(probe->pickname));
-	    match = 1;
-	}
-
-	next = sig->next_ptr;
-	row++;
+        add_to_list(probe->lists[tab], name, NUM_COLS);
+        if (probe->sig == sig) {
+            match_tab = tab;
+            match_row = row;
+        }
+        next = sig->next_ptr;
+        row++;
     }
-    gtk_clist_thaw(GTK_CLIST(probe->lists[1]));
-    // if no match, unselect the first row, otherwise it will stay selected
-    // and confuse the user
-    if (!match)
-    	gtk_clist_unselect_row(GTK_CLIST(probe->lists[1]), 0, 0);
 
     next = hal_data->param_list_ptr;
-    row = 0; match = 0;
-    gtk_clist_freeze(GTK_CLIST(probe->lists[2]));
+    row = 0;
+    tab = 2;
     while (next != 0) {
-	param = SHMPTR(next);
-	name = param->name;
-	gtk_clist_append(GTK_CLIST(probe->lists[2]), &name);
+        param = SHMPTR(next);
+        *name = param->name;
 
-	/* if we have a param selected, and it matches the current
-	   one, mark this row) */
-	if ((probe->listnum == 2) && (probe->param == param)) {
-	    gtk_clist_select_row(GTK_CLIST(probe->lists[2]), row, 0);
-	    /* Get the text from the list */
-	    gtk_clist_get_text(GTK_CLIST(probe->lists[2]), row, 0,
-		&(probe->pickname));
-	    match = 1;
-	}
-	
-	next = param->next_ptr;
-	row++;
-    }
-    gtk_clist_thaw(GTK_CLIST(probe->lists[2]));
-    // if no match, unselect the first row, otherwise it will stay selected
-    // and confuse the user
-    if (!match)
-    	gtk_clist_unselect_row(GTK_CLIST(probe->lists[2]), 0, 0);
-
-    if (probe->listnum >= 0) {
-	gtk_notebook_set_page(GTK_NOTEBOOK(probe->notebook), probe->listnum);
-    } else { //nothing selected, select the first (pin page)
-	gtk_notebook_set_page(GTK_NOTEBOOK(probe->notebook), 0);
+        add_to_list(probe->lists[tab], name, NUM_COLS);
+        if (probe->param == param) {
+            match_tab = tab;
+            match_row = row;
+        }
+        next = param->next_ptr;
+        row++;
     }
 
     rtapi_mutex_give(&(hal_data->mutex));
     gtk_widget_show_all(probe->window);
+
+    if (probe->pickname != NULL) {
+        gtk_notebook_set_current_page(GTK_NOTEBOOK(probe->notebook), match_tab);
+        mark_selected_row(probe->lists[match_tab], match_row);
+    }
 }
 
 static void quit(int sig)
@@ -614,97 +589,73 @@ static char *data_value(int type, void *valptr)
 
 static void create_probe_window(probe_t * probe)
 {
-    GtkWidget *vbox, *hbox, *notebk;
+    GtkWidget *vbox, *hbox;
+    GtkWidget *label;
     GtkWidget *button_close;
     GtkWidget *scrolled_window;
-    gchar *tab_label_text[3];
-    gint n;
+    GtkTreeSelection *selection;
 
-    /* create window, set it's size */
+    char *tab_label_text[3];
+    int n;
+
+    /* create window, set size and title */
     probe->window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    gtk_widget_set_usize(GTK_WIDGET(probe->window), -2, 400);
-    /* allow user to grow but not shrink the window */
-    gtk_window_set_policy(GTK_WINDOW(probe->window), FALSE, TRUE, FALSE);
-    /* set set_probe window title */
+    gtk_widget_set_size_request(GTK_WIDGET(probe->window), -1, 400);
     gtk_window_set_title(GTK_WINDOW(probe->window), probe->probe_name);
 
-    /* a vbox to hold everything */
-    vbox = gtk_vbox_new(FALSE, 3);
+    /* a box to hold everything, add it to window */
+    vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 3);
     gtk_container_set_border_width(GTK_CONTAINER(vbox), 2);
-    /* add the vbox to the window */
     gtk_container_add(GTK_CONTAINER(probe->window), vbox);
-    gtk_widget_show(vbox);
 
-    /* create a notebook to hold pin, signal, and parameter lists */
-    notebk = gtk_notebook_new();
-    /* remember the notebook so we can change the pages later */
-    probe->notebook = notebk;
-    /* add the notebook to the window */
-    gtk_box_pack_start(GTK_BOX(vbox), notebk, TRUE, TRUE, 0);
-    /* set overall notebook parameters */
-    gtk_notebook_set_homogeneous_tabs(GTK_NOTEBOOK(notebk), TRUE);
+    /* create a notebook to hold pin, signal, and parameter list */
+    probe->notebook = gtk_notebook_new();
+    gtk_box_pack_start(GTK_BOX(vbox), probe->notebook, TRUE, TRUE, 0);
+
     /* text for tab labels */
     tab_label_text[0] = _(" _Pins ");
     tab_label_text[1] = _(" _Signals ");
     tab_label_text[2] = _(" Para_meters ");
+
     /* loop to create three identical tabs */
     for (n = 0; n < 3; n++) {
-	/* Create a scrolled window to display the list */
-	scrolled_window = gtk_scrolled_window_new(NULL, NULL);
-	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_window),
-	    GTK_POLICY_AUTOMATIC, GTK_POLICY_ALWAYS);
-	gtk_widget_show(scrolled_window);
-	/* create a list to hold the data */
-	probe->lists[n] = gtk_clist_new(1);
-	/* set up a callback for when the user selects a line */
-	gtk_signal_connect(GTK_OBJECT(probe->lists[n]), "select_row",
-	    GTK_SIGNAL_FUNC(selection_made), probe);
-	/* set up a callback for when the user presses a key */
-	gtk_signal_connect(GTK_OBJECT(probe->lists[n]), "key_press_event",
-	    GTK_SIGNAL_FUNC(key_press), probe );
-	/* It isn't necessary to shadow the border, but it looks nice :) */
-	gtk_clist_set_shadow_type(GTK_CLIST(probe->lists[n]), GTK_SHADOW_OUT);
-	/* set list for single selection only */
-	gtk_clist_set_selection_mode(GTK_CLIST(probe->lists[n]),
-	    GTK_SELECTION_BROWSE);
-	/* put the list into the scrolled window */
-	gtk_container_add(GTK_CONTAINER(scrolled_window), probe->lists[n]);
-	gtk_widget_show(probe->lists[n]);
-	/* create a box for the tab label */
-	hbox = gtk_hbox_new(TRUE, 0);
-	/* create a label for the page */
-	gtk_label_new_in_box(tab_label_text[n], hbox, TRUE, TRUE, 0);
-	gtk_widget_show(hbox);
-	/* add page to the notebook */
-	gtk_notebook_append_page(GTK_NOTEBOOK(notebk), scrolled_window, hbox);
-	gtk_signal_connect(GTK_OBJECT(notebk), "switch-page",
-	    GTK_SIGNAL_FUNC(page_switched), probe);
-	/* set tab attributes */
-	gtk_notebook_set_tab_label_packing(GTK_NOTEBOOK(notebk), hbox,
-	    TRUE, TRUE, GTK_PACK_START);
+        /* Create a scrolled window to display the list */
+        scrolled_window = gtk_scrolled_window_new(NULL, NULL);
+        gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_window),
+            GTK_POLICY_AUTOMATIC, GTK_POLICY_ALWAYS);
+
+        /* create and set tabs in notebook */
+        label = gtk_label_new_with_mnemonic(tab_label_text[n]);
+        gtk_widget_set_size_request(label, 70, -1);
+        gtk_notebook_append_page(GTK_NOTEBOOK(probe->notebook), scrolled_window, label);
+
+        /* create and initalize the list to hold the data */
+        probe->lists[n] = gtk_tree_view_new();
+        gtk_tree_view_set_headers_visible(
+                GTK_TREE_VIEW(probe->lists[n]), FALSE);
+        init_list(probe->lists[n], &tab_label_text[n], NUM_COLS);
+        selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(probe->lists[n]));
+        gtk_container_add(GTK_CONTAINER(scrolled_window), probe->lists[n]);
+
+        /* signals related to the lists */
+        g_signal_connect_swapped(probe->lists[n], "row-activated",
+                G_CALLBACK(gtk_widget_destroy), probe->window);
+        g_signal_connect(selection, "changed",
+                G_CALLBACK(on_changed), probe);
     }
-    /* this selects the page holding the current selected probe */
-    gtk_widget_show(notebk);
-    probe->listnum=0;
 
-    /* an hbox to hold the OK, apply, and cancel buttons */
+    /* create a box and a close button */
     hbox = gtk_hbox_new_in_box(TRUE, 0, 0, vbox, FALSE, TRUE, 0);
-
-    /* create the close button and add it to the hbox */
-    button_close = gtk_button_new_with_label(_("_Close"));
-    gtk_button_set_use_underline((GtkButton *)button_close, TRUE);
+    button_close = gtk_button_new_with_mnemonic(_("_Close"));
     gtk_box_pack_start(GTK_BOX(hbox), button_close, TRUE, TRUE, 4);
 
-    /* make the window disappear if 'close' button is clicked */
-    gtk_signal_connect(GTK_OBJECT(button_close), "clicked",
-	GTK_SIGNAL_FUNC(close_selection), probe);
-    gtk_widget_show(button_close);
-
-    /* set probe->window to NULL if window is destroyed */
-    gtk_signal_connect(GTK_OBJECT(probe->window), "destroy",
-	GTK_SIGNAL_FUNC(gtk_widget_destroyed), &(probe->window));
-
-    /* done */
+    /* signals */
+    g_signal_connect(probe->notebook, "switch-page",
+            G_CALLBACK(page_switched), probe);
+    g_signal_connect_swapped(button_close, "clicked",
+            G_CALLBACK(gtk_widget_destroy), probe->window);
+    g_signal_connect(probe->window, "destroy",
+            G_CALLBACK(gtk_widget_destroyed), &(probe->window));
 }
 
 static void apply_selection(GtkWidget * widget, gpointer data)
@@ -736,90 +687,31 @@ static void apply_selection(GtkWidget * widget, gpointer data)
        wish to display, or all three are NULL if the item doesn't exist */
 }
 
-static void close_selection(GtkWidget * widget, gpointer data)
+/* Keeps track of which tab was last used. */
+static void page_switched(GtkNotebook *notebook, GtkWidget *page,
+                          guint page_num, gpointer user_data)
 {
     probe_t *probe;
-
-    /* get a pointer to the probe data structure */
-    probe = (probe_t *) data;
-    /* destroy the window, hiding it causes problems when showing again */
-    // it wouldn't always switch to the same tab, which causes confusion
-    // we need to rebuild the lists anyways, 
-    // so rebuilding it doesn't take that longer
-    gtk_widget_destroy(probe->window);
-}
-
-static gboolean key_press(GtkWidget *clist, GdkEventKey *event, gpointer user_data)
-{
-    gchar *name, *key;
-    int row, data_good;
-    probe_t *probe;
-
-    /* get a pointer to the probe data structure */
     probe = (probe_t *) user_data;
-
-    /*printf("key pressed: %s\n",gdk_keyval_name(event->keyval) );*/
-    if (event->keyval) {
-        row = 0; data_good = 1;
-
-        while (data_good != 0) {
-            key = (gdk_keyval_name (event->keyval));
-            data_good = gtk_clist_get_text(GTK_CLIST(clist), row, 0, &name );
-            // printf("check: %s %c\n",key,name[0]);
-
-            /* is keypress same as first letter of name? */
-            if (*key == name[0]) {
-                gtk_clist_moveto(GTK_CLIST(probe->lists[probe->listnum]), row, 0,.5,0);
-
-                /* This code would select the found name but didn't move
-                    the cursor position. So after jumping to the selected
-                    letter, if you cursored, it would jump back to the
-                    previous selection- I think too confusing - shame I preferred
-                    the behaivour */
-
-                /*gtk_clist_undo_selection (GTK_CLIST(probe->lists[probe->listnum]));
-                gtk_clist_select_row(GTK_CLIST(probe->lists[probe->listnum]), row, 0);
-                gtk_clist_get_text(GTK_CLIST(clist), row, 0, &(probe->pickname));
-                apply_selection(GTK_WIDGET(probe->window), probe);*/
-                return 0;
-            }
-            row++;
-        }
-    }
-    return 0;
+    probe->listnum=page_num;
 }
 
-/* If we come here, then the user has selected a row in the list. */
-static void selection_made(GtkWidget * clist, gint row, gint column,
-    GdkEventButton * event, gpointer data)
+/*
+ * This gets triggered with the "changed" event. Get the name of the selected
+ * row and updates probe->pickname.
+ *
+ * Calls the function apply_selection to update the label in the main window.
+ */
+static void on_changed(GtkWidget *widget,  gpointer data)
 {
     probe_t *probe;
-
-    /* get a pointer to the probe data structure */
     probe = (probe_t *) data;
 
-    if (clist == NULL) {
-	/* We get spurious events when the lists are populated I don't know
-	   why.  If clist is null, it's a bad one! */
-	return;
-    }
+    GtkTreeIter iter;
+    GtkTreeModel *model;
 
-    if (event) {
-        /* If we get here, it should be a valid selection */
-        /* Get the text from the list */
-        gtk_clist_get_text(GTK_CLIST(clist), row, 0, &(probe->pickname));
+    if (gtk_tree_selection_get_selected(GTK_TREE_SELECTION(widget), &model, &iter)) {
+        gtk_tree_model_get(model, &iter, LIST_ITEM, &(probe->pickname), -1);
         apply_selection(GTK_WIDGET(probe->window), probe);
-        if (event->type == GDK_2BUTTON_PRESS) {
-            close_selection(GTK_WIDGET(probe->window), probe);
-        }
-        return;
-    } 
-
-}
-
-static void page_switched(GtkNotebook *notebook, GtkNotebookPage *page,
-		guint page_num, gpointer user_data)
-{
-	// update the listnum in probe data, because 
-	((probe_t *)user_data)->listnum=page_num;
+    }
 }

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -207,7 +207,7 @@ void gtk_label_size_to_fit(GtkLabel * label, const gchar * str)
     /* set the label to display the new text */
     gtk_label_set_text(label, str);
     /* how big is the label with the new text? */
-    gtk_widget_size_request(GTK_WIDGET(label), &req);
+    gtk_widget_get_preferred_size(GTK_WIDGET(label), NULL, &req);
     /* freeze it at this size */
     gtk_widget_set_size_request(GTK_WIDGET(label), req.width, req.height);
     /* restore the old text */

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -375,6 +375,25 @@ void mark_selected_row(GtkWidget *list, const int row)
 
     gtk_tree_view_scroll_to_cell(GTK_TREE_VIEW(list), path, NULL, TRUE, 0.5, 0.5);
 }
+
+void set_file_filter(GtkFileChooser *chooser, const char *str, const char *ext)
+{
+    GtkFileFilter *filter_all;
+    GtkFileFilter *filter_spes;
+
+    filter_all = gtk_file_filter_new();
+    filter_spes = gtk_file_filter_new();
+
+    gtk_file_filter_set_name(filter_all, "All files");
+    gtk_file_filter_add_pattern(filter_all, "*");
+    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(chooser), filter_all);
+
+    gtk_file_filter_set_name(filter_spes, str);
+    gtk_file_filter_add_pattern(filter_spes, ext);
+    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(chooser), filter_spes);
+    gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(chooser), filter_spes);
+}
+
 /***********************************************************************
 *                        LOCAL FUNCTION CODE                           *
 ************************************************************************/

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -106,7 +106,7 @@ void gtk_vseparator_new_in_box(GtkWidget * box, guint padding)
 {
     GtkWidget *bar;
 
-    bar = gtk_vseparator_new();
+    bar = gtk_separator_new(GTK_ORIENTATION_VERTICAL);
     gtk_box_pack_start(GTK_BOX(box), bar, FALSE, FALSE, padding);
     gtk_widget_show(bar);
 }
@@ -115,7 +115,7 @@ void gtk_hseparator_new_in_box(GtkWidget * box, guint padding)
 {
     GtkWidget *bar;
 
-    bar = gtk_hseparator_new();
+    bar = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
     gtk_box_pack_start(GTK_BOX(box), bar, FALSE, FALSE, padding);
     gtk_widget_show(bar);
 }
@@ -126,7 +126,8 @@ GtkWidget *gtk_vbox_new_in_box(gboolean homogeneous, guint spacing,
 {
     GtkWidget *vbox;
 
-    vbox = gtk_vbox_new(homogeneous, spacing);
+    vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, spacing);
+    gtk_box_set_homogeneous(GTK_BOX(vbox), homogeneous);
     gtk_container_set_border_width(GTK_CONTAINER(vbox), border);
     gtk_box_pack_start(GTK_BOX(box), vbox, expand, fill, padding);
     gtk_widget_show(vbox);
@@ -139,7 +140,8 @@ GtkWidget *gtk_hbox_new_in_box(gboolean homogeneous, guint spacing,
 {
     GtkWidget *hbox;
 
-    hbox = gtk_hbox_new(homogeneous, spacing);
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, spacing);
+    gtk_box_set_homogeneous(GTK_BOX(hbox), homogeneous);
     gtk_container_set_border_width(GTK_CONTAINER(hbox), border);
     gtk_box_pack_start(GTK_BOX(box), hbox, expand, fill, padding);
     gtk_widget_show(hbox);
@@ -155,7 +157,8 @@ GtkWidget *gtk_vbox_framed_new_in_box(const gchar * name, gboolean homogeneous,
     frame = gtk_frame_new(name);
     gtk_box_pack_start(GTK_BOX(box), frame, expand, fill, padding);
     gtk_widget_show(frame);
-    vbox = gtk_vbox_new(homogeneous, spacing);
+    vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, spacing);
+    gtk_box_set_homogeneous(GTK_BOX(vbox), homogeneous);
     gtk_container_set_border_width(GTK_CONTAINER(vbox), border);
     gtk_container_add(GTK_CONTAINER(frame), vbox);
     gtk_widget_show(vbox);
@@ -171,7 +174,8 @@ GtkWidget *gtk_hbox_framed_new_in_box(const gchar * name, gboolean homogeneous,
     frame = gtk_frame_new(name);
     gtk_box_pack_start(GTK_BOX(box), frame, expand, fill, padding);
     gtk_widget_show(frame);
-    hbox = gtk_hbox_new(homogeneous, spacing);
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, spacing);
+    gtk_box_set_homogeneous(GTK_BOX(hbox), homogeneous);
     gtk_container_set_border_width(GTK_CONTAINER(hbox), border);
     gtk_container_add(GTK_CONTAINER(frame), hbox);
     gtk_widget_show(hbox);
@@ -240,7 +244,10 @@ int dialog_generic_msg(GtkWidget * parent, const gchar * title, const gchar * ms
     }
     if (msg != NULL) {
 	label = gtk_label_new(msg);
-	gtk_misc_set_padding(GTK_MISC(label), 15, 15);
+	gtk_widget_set_margin_top(label, 15);
+	gtk_widget_set_margin_bottom(label, 15);
+	gtk_widget_set_margin_start(label, 15);
+	gtk_widget_set_margin_end(label, 15);
     gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
             label, TRUE, TRUE, 0);
     }

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -310,6 +310,71 @@ void dialog_generic_destroyed(GtkWidget * widget, dialog_generic_t * dptr)
     gtk_main_quit();
 }
 
+void add_to_list(GtkWidget *list, char *strs[], const int num_cols)
+{
+    GtkListStore *store;
+    GtkTreeIter iter;
+
+    store = GTK_LIST_STORE(gtk_tree_view_get_model(GTK_TREE_VIEW(list)));
+
+    /* Hardcoded to only support one and two columns. */
+    gtk_list_store_append(store, &iter);
+    if (num_cols == 1) {
+        gtk_list_store_set(store, &iter, 0, strs[0], -1);
+    } else if (num_cols == 2) {
+        gtk_list_store_set(store, &iter, 0, strs[0], 1, strs[1], -1);
+    } else {
+        printf("Failed to add item, to TreeView list\n");
+    }
+}
+
+void init_list(GtkWidget *list, char *titles[], const int len)
+{
+    GtkCellRenderer *renderer;
+    GtkListStore *store;
+
+    int i;
+
+    for (i = 0; i < len; i++) {
+        renderer = gtk_cell_renderer_text_new ();
+        gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(list),
+                -1, titles[i], renderer, "text", i, NULL);
+    }
+
+    store = gtk_list_store_new(len, G_TYPE_STRING, G_TYPE_STRING);
+
+    gtk_tree_view_set_model(GTK_TREE_VIEW(list), GTK_TREE_MODEL(store));
+
+    g_object_unref(store);
+}
+
+void clear_list(GtkWidget *list)
+{
+    GtkListStore *store;
+    GtkTreeModel *model;
+    GtkTreeIter iter;
+
+    store = GTK_LIST_STORE(gtk_tree_view_get_model(GTK_TREE_VIEW(list)));
+    model = gtk_tree_view_get_model(GTK_TREE_VIEW(list));
+
+    if (gtk_tree_model_get_iter_first(model, &iter) == FALSE) {
+        return;
+    }
+
+    gtk_list_store_clear(store);
+}
+
+void mark_selected_row(GtkWidget *list, const int row)
+{
+    GtkTreePath *path;
+    GtkTreeSelection *selection;
+
+    path = gtk_tree_path_new_from_indices(row, -1);
+    selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list));
+    gtk_tree_selection_select_path(selection, path);
+
+    gtk_tree_view_scroll_to_cell(GTK_TREE_VIEW(list), path, NULL, TRUE, 0.5, 0.5);
+}
 /***********************************************************************
 *                        LOCAL FUNCTION CODE                           *
 ************************************************************************/

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -209,7 +209,7 @@ void gtk_label_size_to_fit(GtkLabel * label, const gchar * str)
     /* how big is the label with the new text? */
     gtk_widget_size_request(GTK_WIDGET(label), &req);
     /* freeze it at this size */
-    gtk_widget_set_usize(GTK_WIDGET(label), req.width, req.height);
+    gtk_widget_set_size_request(GTK_WIDGET(label), req.width, req.height);
     /* restore the old text */
     gtk_label_set_text(label, text_buf);
     /* free the buffer */
@@ -230,7 +230,7 @@ int dialog_generic_msg(GtkWidget * parent, const gchar * title, const gchar * ms
     dialog.retval = 0;
     /* create dialog window, disable resizing */
     dialog.window = gtk_dialog_new();
-    gtk_window_set_policy(GTK_WINDOW(dialog.window), FALSE, FALSE, FALSE);
+    gtk_window_set_resizable(GTK_WINDOW(dialog.window), FALSE);
     /* set title */
     if (title != NULL) {
 	gtk_window_set_title(GTK_WINDOW(dialog.window), title);

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -222,7 +222,7 @@ int dialog_generic_msg(GtkWidget * parent, const gchar * title, const gchar * ms
     const gchar * button1, const gchar * button2, const gchar * button3, const gchar * button4)
 {
     dialog_generic_t dialog;
-    GtkWidget *button, *label;
+    GtkWidget *button, *label, *content_area;
     const gchar *button_name_array[4];
     void (*button_funct_array[4]) (GtkWidget *, dialog_generic_t *);
     gint n;
@@ -231,6 +231,7 @@ int dialog_generic_msg(GtkWidget * parent, const gchar * title, const gchar * ms
     /* create dialog window, disable resizing */
     dialog.window = gtk_dialog_new();
     gtk_window_set_resizable(GTK_WINDOW(dialog.window), FALSE);
+    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog.window));
     /* set title */
     if (title != NULL) {
 	gtk_window_set_title(GTK_WINDOW(dialog.window), title);
@@ -239,9 +240,9 @@ int dialog_generic_msg(GtkWidget * parent, const gchar * title, const gchar * ms
     }
     if (msg != NULL) {
 	label = gtk_label_new(msg);
-	gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->vbox), label,
-	    TRUE, TRUE, 0);
 	gtk_misc_set_padding(GTK_MISC(label), 15, 15);
+    gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
+            label, TRUE, TRUE, 0);
     }
     /* set up a callback function when the window is destroyed */
     g_signal_connect(dialog.window, "destroy",
@@ -260,11 +261,11 @@ int dialog_generic_msg(GtkWidget * parent, const gchar * title, const gchar * ms
     for (n = 0; n < 4; n++) {
 	if (button_name_array[n] != NULL) {
 	    /* make a button */
-	    button = gtk_button_new_with_label(button_name_array[n]);
-	    gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->
-		    action_area), button, TRUE, TRUE, 4);
-	    g_signal_connect(button, "clicked",
-		G_CALLBACK(button_funct_array[n]), &dialog);
+            button = gtk_button_new_with_label(button_name_array[n]);
+            g_signal_connect(button, "clicked",
+                    G_CALLBACK(button_funct_array[n]), &dialog);
+            gtk_dialog_add_action_widget(GTK_DIALOG(dialog.window),
+                    button, n + 1);
 	}
     }
     if (parent != NULL) {

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -188,12 +188,12 @@ void gtk_label_set_text_if(GtkWidget * label, const gchar * text)
 void gtk_label_size_to_fit(GtkLabel * label, const gchar * str)
 {
     GtkRequisition req;
-    gchar *current_text;
+    const gchar *current_text;
     gint text_len;
     gchar *text_buf;
 
     /* get a pointer to the current text */
-    gtk_label_get(label, &current_text);
+    current_text = gtk_label_get_text(label);
     /* how long is it */
     text_len = strlen(current_text);
     /* allocate memory to save it */

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -244,8 +244,8 @@ int dialog_generic_msg(GtkWidget * parent, const gchar * title, const gchar * ms
 	gtk_misc_set_padding(GTK_MISC(label), 15, 15);
     }
     /* set up a callback function when the window is destroyed */
-    gtk_signal_connect(GTK_OBJECT(dialog.window), "destroy",
-	GTK_SIGNAL_FUNC(dialog_generic_destroyed), &dialog);
+    g_signal_connect(dialog.window, "destroy",
+	G_CALLBACK(dialog_generic_destroyed), &dialog);
     /* transfer button name pointers to an array for looping */
     button_name_array[0] = button1;
     button_name_array[1] = button2;
@@ -263,8 +263,8 @@ int dialog_generic_msg(GtkWidget * parent, const gchar * title, const gchar * ms
 	    button = gtk_button_new_with_label(button_name_array[n]);
 	    gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->
 		    action_area), button, TRUE, TRUE, 4);
-	    gtk_signal_connect(GTK_OBJECT(button), "clicked",
-		GTK_SIGNAL_FUNC(button_funct_array[n]), &dialog);
+	    g_signal_connect(button, "clicked",
+		G_CALLBACK(button_funct_array[n]), &dialog);
 	}
     }
     if (parent != NULL) {

--- a/src/hal/utils/miscgtk.h
+++ b/src/hal/utils/miscgtk.h
@@ -139,4 +139,18 @@ void dialog_generic_button3(GtkWidget * widget, dialog_generic_t * dptr);
 void dialog_generic_button4(GtkWidget * widget, dialog_generic_t * dptr);
 void dialog_generic_destroyed(GtkWidget * widget, dialog_generic_t * dptr);
 
+/* Initialize a TreeView. */
+void init_list(GtkWidget *list, char *titles[], const int num_cols);
+
+/* Add new row to a TreeView. */
+void add_to_list(GtkWidget *list, char *strs[], const int num);
+
+/* Clears all elements from a TreeView list. */
+void clear_list(GtkWidget *list);
+
+/** If a row has  previously been selected, this function ensures that it
+    will be selected again.
+*/
+void mark_selected_row(GtkWidget *list, const int row);
+
 #endif /* MISCGTK_H */

--- a/src/hal/utils/miscgtk.h
+++ b/src/hal/utils/miscgtk.h
@@ -153,4 +153,7 @@ void clear_list(GtkWidget *list);
 */
 void mark_selected_row(GtkWidget *list, const int row);
 
+/* Set a file filter for the open and save dialog boxes. */
+void set_file_filter(GtkFileChooser *chooser, const char *str, const char *ext);
+
 #endif /* MISCGTK_H */

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -1,7 +1,7 @@
 /** This file, 'scope.c', is a GUI program that together with
     'scope_rt.c' serves as an oscilloscope to examine HAL pins,
     signals, and parameters.  It is a user space component and
-    uses GTK 1.2 or 2.0 for the GUI code.
+    uses GTK 3.0 for the GUI code.
 */
 
 static char *license = \
@@ -623,7 +623,7 @@ static void define_scope_windows(void)
 
     /* create main window, set its minimum size and title */
     ctrl_usr->main_win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    gtk_widget_set_size_request(GTK_WIDGET(ctrl_usr->main_win), 500, 350);
+    gtk_widget_set_size_request(GTK_WIDGET(ctrl_usr->main_win), 650, 400);
     gtk_window_set_title(GTK_WINDOW(ctrl_usr->main_win), _("HAL Oscilloscope"));
 
     /* top level - big vbox, menu above, everything else below */

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -621,13 +621,9 @@ static void define_scope_windows(void)
 {
     GtkWidget *vbox, *hbox, *vboxtop, *vboxbottom, *vboxleft, *vboxright, *hboxright;
 
-    /* create main window, set its size */
+    /* create main window, set its minimum size and title */
     ctrl_usr->main_win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    /* set the minimum size */
-    gtk_widget_set_usize(GTK_WIDGET(ctrl_usr->main_win), 500, 350);
-    /* allow the user to expand it */
-    gtk_window_set_policy(GTK_WINDOW(ctrl_usr->main_win), FALSE, TRUE, FALSE);
-    /* set main window title */
+    gtk_widget_set_size_request(GTK_WIDGET(ctrl_usr->main_win), 500, 350);
     gtk_window_set_title(GTK_WINDOW(ctrl_usr->main_win), _("HAL Oscilloscope"));
 
     /* top level - big vbox, menu above, everything else below */

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -190,10 +190,10 @@ int main(int argc, gchar * argv[])
     /* set main window */
     define_scope_windows();
     /* this makes the application exit when the window is closed */
-    gtk_signal_connect(GTK_OBJECT(ctrl_usr->main_win), "destroy",
-	GTK_SIGNAL_FUNC(main_window_closed), NULL);
-    gtk_signal_connect(GTK_OBJECT(ctrl_usr->main_win), "focus-in-event",
-	GTK_SIGNAL_FUNC(set_focus), NULL);
+    g_signal_connect(ctrl_usr->main_win, "destroy",
+	G_CALLBACK(main_window_closed), NULL);
+    g_signal_connect(ctrl_usr->main_win, "focus-in-event",
+	G_CALLBACK(set_focus), NULL);
     /* define menu windows */
     /* do next level of init */
     init_horiz();

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -699,17 +699,14 @@ static void define_scope_windows(void)
 
 static void init_run_mode_window(void)
 {
-    /* define the radio buttons */
+    /* define the radio buttons and group them */
     ctrl_usr->rm_stop_button = gtk_radio_button_new_with_label(NULL, _("Stop"));
-    ctrl_usr->rm_normal_button =
-	gtk_radio_button_new_with_label(gtk_radio_button_group
-	(GTK_RADIO_BUTTON(ctrl_usr->rm_stop_button)), _("Normal"));
-    ctrl_usr->rm_single_button =
-	gtk_radio_button_new_with_label(gtk_radio_button_group
-	(GTK_RADIO_BUTTON(ctrl_usr->rm_stop_button)), _("Single"));
-    ctrl_usr->rm_roll_button =
-	gtk_radio_button_new_with_label(gtk_radio_button_group
-	(GTK_RADIO_BUTTON(ctrl_usr->rm_stop_button)), _("Roll"));
+    ctrl_usr->rm_normal_button = gtk_radio_button_new_with_label_from_widget(
+            GTK_RADIO_BUTTON(ctrl_usr->rm_stop_button), _("Normal"));
+    ctrl_usr->rm_single_button = gtk_radio_button_new_with_label_from_widget(
+            GTK_RADIO_BUTTON(ctrl_usr->rm_stop_button), _("Single"));
+    ctrl_usr->rm_roll_button = gtk_radio_button_new_with_label_from_widget(
+            GTK_RADIO_BUTTON(ctrl_usr->rm_stop_button), _("Roll"));
     /* now put them into the box */
     gtk_box_pack_start(GTK_BOX(ctrl_usr->run_mode_win),
 	ctrl_usr->rm_normal_button, FALSE, FALSE, 0);
@@ -720,14 +717,14 @@ static void init_run_mode_window(void)
     gtk_box_pack_start(GTK_BOX(ctrl_usr->run_mode_win),
 	ctrl_usr->rm_stop_button, FALSE, FALSE, 0);
     /* hook callbacks to buttons */
-    gtk_signal_connect(GTK_OBJECT(ctrl_usr->rm_normal_button), "clicked",
-	GTK_SIGNAL_FUNC(rm_normal_button_clicked), NULL);
-    gtk_signal_connect(GTK_OBJECT(ctrl_usr->rm_single_button), "clicked",
-	GTK_SIGNAL_FUNC(rm_single_button_clicked), NULL);
-    gtk_signal_connect(GTK_OBJECT(ctrl_usr->rm_roll_button), "clicked",
-	GTK_SIGNAL_FUNC(rm_roll_button_clicked), NULL);
-    gtk_signal_connect(GTK_OBJECT(ctrl_usr->rm_stop_button), "clicked",
-	GTK_SIGNAL_FUNC(rm_stop_button_clicked), NULL);
+    g_signal_connect(ctrl_usr->rm_normal_button, "clicked",
+            G_CALLBACK(rm_normal_button_clicked), NULL);
+    g_signal_connect(ctrl_usr->rm_single_button, "clicked",
+            G_CALLBACK(rm_single_button_clicked), NULL);
+    g_signal_connect(ctrl_usr->rm_roll_button, "clicked",
+            G_CALLBACK(rm_roll_button_clicked), NULL);
+    g_signal_connect(ctrl_usr->rm_stop_button, "clicked",
+            G_CALLBACK(rm_stop_button_clicked), NULL);
     /* and make them visible */
     gtk_widget_show(ctrl_usr->rm_normal_button);
     gtk_widget_show(ctrl_usr->rm_single_button);

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -536,46 +536,46 @@ static void define_menubar(GtkWidget *vboxtop) {
     sep2 = gtk_separator_menu_item_new();
 
     fileopenconfiguration = gtk_menu_item_new_with_mnemonic(_("_Open Configuration..."));
-    gtk_menu_append(GTK_MENU(filemenu), fileopenconfiguration);
-    gtk_signal_connect_object(GTK_OBJECT(fileopenconfiguration), "activate", 
-            GTK_SIGNAL_FUNC(open_configuration), 0);
+    gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), fileopenconfiguration);
+    g_signal_connect_swapped(fileopenconfiguration, "activate",
+            G_CALLBACK(open_configuration), 0);
     gtk_widget_show(fileopenconfiguration);
     
     filesaveconfiguration = gtk_menu_item_new_with_mnemonic(_("_Save Configuration..."));
-    gtk_menu_append(GTK_MENU(filemenu), filesaveconfiguration);
-    gtk_signal_connect_object(GTK_OBJECT(filesaveconfiguration), "activate", 
-            GTK_SIGNAL_FUNC(save_configuration), 0);
+    gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), filesaveconfiguration);
+    g_signal_connect_swapped(filesaveconfiguration, "activate",
+            G_CALLBACK(save_configuration), 0);
     gtk_widget_show(filesaveconfiguration);
 
-    gtk_menu_append(GTK_MENU(filemenu), sep1);
+    gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), sep1);
     gtk_widget_show(sep1);
     
     fileopendatafile = gtk_menu_item_new_with_mnemonic(_("O_pen Data File..."));
-    gtk_menu_append(GTK_MENU(filemenu), fileopendatafile);
-    gtk_signal_connect_object(GTK_OBJECT(fileopendatafile), "activate", 
-            GTK_SIGNAL_FUNC(menuitem_response), "file/open datafile");
+    gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), fileopendatafile);
+    g_signal_connect_swapped(fileopendatafile, "activate",
+            G_CALLBACK(menuitem_response), "file/open datafile");
     gtk_widget_set_sensitive(GTK_WIDGET(fileopendatafile), FALSE); // XXX
     gtk_widget_show(fileopendatafile);
     
     filesavedatafile = gtk_menu_item_new_with_mnemonic(_("S_ave Data File..."));
-    gtk_menu_append(GTK_MENU(filemenu), filesavedatafile);
-    gtk_signal_connect_object(GTK_OBJECT(filesavedatafile), "activate", 
-            GTK_SIGNAL_FUNC(log_popup), 0);
+    gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), filesavedatafile);
+    g_signal_connect_swapped(filesavedatafile, "activate",
+            G_CALLBACK(log_popup), 0);
     gtk_widget_show(filesavedatafile);
     
-    gtk_menu_append(GTK_MENU(filemenu), sep2);
+    gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), sep2);
     gtk_widget_show(sep2);
 
     filequit = gtk_menu_item_new_with_mnemonic(_("_Quit"));
-    gtk_menu_append(GTK_MENU(filemenu), filequit);
-    gtk_signal_connect_object(GTK_OBJECT(filequit), "activate", 
-            GTK_SIGNAL_FUNC(quit), 0);
+    gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), filequit);
+    g_signal_connect_swapped(filequit, "activate",
+            G_CALLBACK(quit), 0);
     gtk_widget_show(filequit);
 
     helpabout = gtk_menu_item_new_with_mnemonic(_("_About Halscope"));
-    gtk_menu_append(GTK_MENU(helpmenu), helpabout);
-    gtk_signal_connect_object(GTK_OBJECT(helpabout), "activate",
-            GTK_SIGNAL_FUNC(about), 0);
+    gtk_menu_shell_append(GTK_MENU_SHELL(helpmenu), helpabout);
+    g_signal_connect_swapped(helpabout, "activate",
+            G_CALLBACK(about), 0);
     gtk_widget_show(helpabout);
 
     file_rootmenu = gtk_menu_item_new_with_mnemonic(_("_File"));
@@ -594,8 +594,8 @@ static void define_menubar(GtkWidget *vboxtop) {
     gtk_box_pack_start(GTK_BOX(vbox), menubar, FALSE, FALSE, 2);
     gtk_widget_show(menubar);
 
-    gtk_menu_bar_append(GTK_MENU_BAR(menubar), file_rootmenu);
-    gtk_menu_bar_append(GTK_MENU_BAR(menubar), help_rootmenu);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menubar), file_rootmenu);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menubar), help_rootmenu);
 }
 
 /** 'define_scope_windows()' defines the overall layout of the main

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -246,7 +246,7 @@ static int heartbeat(gpointer data)
 	/* decrement timer, did it time out? */
 	if (--ctrl_usr->display_refresh_timer == 0) {
 	    /* yes, refresh the display */
-	    refresh_display();
+	    redraw_window();
 	}
     }
     if (ctrl_shm->state == DONE) {
@@ -371,7 +371,7 @@ void capture_copy_data(void) {
 void capture_cont()
 {
     capture_copy_data();
-    refresh_display();
+    redraw_window();
 }
 
 void capture_complete(void)
@@ -396,7 +396,7 @@ void capture_complete(void)
 	
 	//uncomment me to write log files
 	//write_log_file("scope.log");
-    refresh_display();
+    redraw_window();
 }
 
 /***********************************************************************
@@ -457,7 +457,7 @@ static void do_open_configuration(char *filename)
     }
     read_config_file(filename);
     channel_changed();
-    refresh_display();
+    redraw_window();
 }
 
 static void open_configuration(GtkWindow *parent)

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -573,7 +573,7 @@ static void define_menubar(GtkWidget *vboxtop) {
     gtk_widget_show(help_rootmenu);
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(help_rootmenu),helpmenu);
 
-    vbox = gtk_vbox_new(FALSE, 0);
+    vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_container_add(GTK_CONTAINER(vboxtop), vbox);
     gtk_widget_show(vbox);
 
@@ -627,7 +627,7 @@ static void define_scope_windows(void)
     gtk_window_set_title(GTK_WINDOW(ctrl_usr->main_win), _("HAL Oscilloscope"));
 
     /* top level - big vbox, menu above, everything else below */
-    vbox = gtk_vbox_new(FALSE, 0);
+    vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_container_set_border_width(GTK_CONTAINER(vbox), 0);
     gtk_container_add(GTK_CONTAINER(ctrl_usr->main_win), vbox);
     gtk_widget_show(vbox);
@@ -636,7 +636,7 @@ static void define_scope_windows(void)
     vboxbottom = gtk_hbox_new_in_box(FALSE, 0, 0, vbox, TRUE, TRUE, 0);
 
     /* one big hbox for everything under the menu */
-    hbox = gtk_hbox_new(FALSE, 0);
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     gtk_container_set_border_width(GTK_CONTAINER(hbox), 0);
     /* add the hbox to the main window */
     gtk_container_add(GTK_CONTAINER(vboxbottom), hbox);
@@ -657,6 +657,8 @@ static void define_scope_windows(void)
     /* horizontal row of select buttons */
     ctrl_usr->waveform_win =
 	gtk_vbox_new_in_box(FALSE, 0, 0, vboxleft, TRUE, TRUE, 0);
+    gtk_widget_set_vexpand(ctrl_usr->waveform_win, TRUE);
+    gtk_widget_set_hexpand(ctrl_usr->waveform_win, TRUE);
     ctrl_usr->chan_sel_win =
 	gtk_hbox_new_in_box(TRUE, 0, 0, vboxleft, FALSE, FALSE, 0);
     ctrl_usr->chan_info_win =

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -211,7 +211,7 @@ int main(int argc, gchar * argv[])
     /* read the saved config file */
     read_config_file(ifilename);
     /* arrange for periodic call of heartbeat() */
-    gtk_timeout_add(100, heartbeat, NULL);
+    g_timeout_add(100, heartbeat, NULL);
     /* enter the main loop */
     gtk_main();
     write_config_file(ofilename);

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -353,16 +353,16 @@ static void init_display_window(void)
     gtk_box_pack_start(GTK_BOX(ctrl_usr->waveform_win), disp->drawing, TRUE,
 	TRUE, 0);
     /* hook up a function to handle expose events */
-    gtk_signal_connect(GTK_OBJECT(disp->drawing), "expose_event",
-	GTK_SIGNAL_FUNC(handle_window_expose), NULL);
-    gtk_signal_connect(GTK_OBJECT(disp->drawing), "button_release_event",
-        GTK_SIGNAL_FUNC(handle_release), NULL);
-    gtk_signal_connect(GTK_OBJECT(disp->drawing), "button_press_event",
-        GTK_SIGNAL_FUNC(handle_click), NULL);
-    gtk_signal_connect(GTK_OBJECT(disp->drawing), "motion_notify_event",
-        GTK_SIGNAL_FUNC(handle_motion), NULL);
-    gtk_signal_connect(GTK_OBJECT(disp->drawing), "scroll_event",
-                GTK_SIGNAL_FUNC(handle_scroll), NULL);
+    g_signal_connect(disp->drawing, "expose_event",
+	G_CALLBACK(handle_window_expose), NULL);
+    g_signal_connect(disp->drawing, "button_release_event",
+        G_CALLBACK(handle_release), NULL);
+    g_signal_connect(disp->drawing, "button_press_event",
+        G_CALLBACK(handle_click), NULL);
+    g_signal_connect(disp->drawing, "motion_notify_event",
+        G_CALLBACK(handle_motion), NULL);
+    g_signal_connect(disp->drawing, "scroll_event",
+                G_CALLBACK(handle_scroll), NULL);
     gtk_widget_add_events(GTK_WIDGET(disp->drawing),
             GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
             | GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -587,7 +587,8 @@ static int handle_motion(GtkWidget *widget, GdkEventButton *event, gpointer data
     GdkModifierType mod;
     int x, y;
 
-    gdk_window_get_pointer(gtk_widget_get_window(disp->drawing), &x, &y, &mod);
+    gdk_window_get_device_position(gtk_widget_get_window(disp->drawing),
+            event->device, &x, &y, &mod);
     if(mod & GDK_BUTTON1_MASK) {
         left_drag(y-motion_y, y, event->state);
         return TRUE;
@@ -605,10 +606,7 @@ void update_readout(void) {
     scope_vert_t *vert = &(ctrl_usr->vert);
     scope_horiz_t *horiz = &(ctrl_usr->horiz);
     char tip[512];
-    GdkRectangle r = {vert->readout_label->allocation.x,
-            vert->readout_label->allocation.y,
-            vert->readout_label->allocation.width,
-            vert->readout_label->allocation.height};
+
     if(vert->selected != -1) {
         double t=0, p=0, v=0;
         int result = get_cursor_info(&t, &p, &v);
@@ -622,9 +620,6 @@ void update_readout(void) {
     }
 
     gtk_label_set_markup(GTK_LABEL(vert->readout_label), tip);
-
-    gtk_widget_draw(vert->readout_label, &r);
-
 }
 
 struct pt { double x, y; };

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -60,12 +60,12 @@
 
 static void init_display_window(void);
 static void clear_display_window(void);
+static void alloc_color(GdkRGBA *color, int red, int green, int blue);
 static void update_readout(void);
 static void draw_grid(void);
 static void draw_baseline(int chan_num, int highlight);
 static void draw_waveform(int chan_num, int highlight);
 static void draw_triggerline(int chan_num, int highlight);
-static void handle_window_expose(GtkWidget * widget, gpointer data);
 static int handle_click(GtkWidget *widget, GdkEventButton *event, gpointer data);
 static int handle_release(GtkWidget *widget, GdkEventButton *event, gpointer data);
 static int handle_motion(GtkWidget *widget, GdkEventButton *event, gpointer data);
@@ -73,6 +73,9 @@ static int handle_scroll(GtkWidget *widget, GdkEventScroll *event, gpointer data
 static void conflict_avoid(int *y, int h);
 static int conflict_avoid_dy(int y, int h, int dy);
 static void conflict_reset(int height);
+static void update_drawing_size(GtkWidget *widget, GdkEventConfigure *event,
+        gpointer data);
+static void create_context(void);
 
 /***********************************************************************
 *                       PUBLIC FUNCTIONS                               *
@@ -126,6 +129,17 @@ void request_display_refresh(int delay)
     ctrl_usr->display_refresh_timer = delay;
 }
 
+/*
+ * Redraws the oscilloscope window
+ */
+void redraw_window(void)
+{
+    scope_disp_t *disp;
+    disp = &(ctrl_usr->disp);
+
+    gtk_widget_queue_draw(disp->drawing);
+}
+
 static int motion_x = -1, motion_y = -1;
 
 static void calculate_offset(int chan_num) {
@@ -176,7 +190,6 @@ void refresh_display(void)
     scope_disp_t *disp;
     scope_vert_t *vert;
     scope_horiz_t *horiz;
-    int depth;
     double pixels_per_div, pixels_per_sec, overall_record_length;
     double screen_center_time, screen_start_time, screen_end_time;
 
@@ -186,21 +199,7 @@ void refresh_display(void)
     disp = &(ctrl_usr->disp);
     vert = &(ctrl_usr->vert);
     horiz = &(ctrl_usr->horiz);
-    /* get window pointer */
-    disp->win = gtk_widget_get_window(disp->drawing);
-    if (disp->win == NULL) {
-	/* window isn't visible yet, do nothing */
-	printf("refresh_display(): win = NULL, bailing!\n");
-	return;
-    }
-    /* create drawing context if needed */
-    if (disp->context == NULL) {
-	disp->context = gdk_gc_new(disp->win);
-    }
 
-    /* get window dimensions */
-    gdk_window_get_geometry(disp->win, NULL, NULL, &(disp->width),
-	&(disp->height), &depth);
     /* calculate horizontal params that depend on width */
     pixels_per_div = disp->width * 0.1;
     pixels_per_sec = pixels_per_div / horiz->disp_scale;
@@ -217,13 +216,6 @@ void refresh_display(void)
     disp->end_sample = (screen_end_time / horiz->sample_period) + 1;
     if (disp->end_sample > ctrl_shm->rec_len - 1) {
 	disp->end_sample = ctrl_shm->rec_len - 1;
-    }
-
-    {
-        GdkRectangle rect = {0, 0, disp->width, disp->height};
-        GdkRegion *region = gdk_region_rectangle(&rect);
-        gdk_window_begin_paint_region(gtk_widget_get_window(disp->drawing), region);
-        gdk_region_destroy(region);
     }
 
     DRAWING = 1;
@@ -267,38 +259,22 @@ void refresh_display(void)
     }
 
     update_readout();
-
-    gdk_window_end_paint(gtk_widget_get_window(disp->drawing));
 }
 
 /***********************************************************************
 *                       LOCAL FUNCTIONS                                *
 ************************************************************************/
 
-gboolean alloc_color(GdkColor * color, GdkColormap * map,
-    unsigned char red, unsigned char green, unsigned char blue)
+static void alloc_color(GdkRGBA *color, int red, int green, int blue)
 {
-    int retval;
+    char buf[17];
 
-    color->red = ((unsigned long) red) << 8;
-    color->green = ((unsigned long) green) << 8;
-    color->blue = ((unsigned long) blue) << 8;
-    color->pixel =
-	((unsigned long) red) << 16 | ((unsigned long) green) << 8 |
-	((unsigned long) blue);
-    retval = gdk_colormap_alloc_color(map, color, FALSE, TRUE);
-    if (retval == 0) {
-	printf("alloc_color( %d, %d, %d ) failed\n", red, green, blue);
+    snprintf(buf, sizeof(buf), "rgb(%d,%d,%d)", red, green, blue);
+    if (!gdk_rgba_parse(color, buf)) {
+        fprintf(stderr, "%s: Failed to parse color, RGB(%d, %d, %d)\n",
+                __func__, red, green, blue);
     }
-    return retval;
 }
-
-#if 0 /* this will be needed if/when I allow user defined colors */
-static void free_color(GdkColor * color, GdkColormap * map)
-{
-    gdk_colormap_free_colors(map, color, 1);
-}
-#endif
 
 int normal_colors[16][3] = {
 	{204,   0,   0},
@@ -353,8 +329,12 @@ static void init_display_window(void)
     gtk_box_pack_start(GTK_BOX(ctrl_usr->waveform_win), disp->drawing, TRUE,
 	TRUE, 0);
     /* hook up a function to handle expose events */
-    g_signal_connect(disp->drawing, "expose_event",
-	G_CALLBACK(handle_window_expose), NULL);
+    g_signal_connect(disp->drawing, "size_allocate",
+        G_CALLBACK(update_drawing_size), NULL);
+    g_signal_connect(disp->drawing, "realize",
+        G_CALLBACK(create_context), NULL);
+    g_signal_connect(disp->drawing, "draw",
+	G_CALLBACK(refresh_display), NULL);
     g_signal_connect(disp->drawing, "button_release_event",
         G_CALLBACK(handle_release), NULL);
     g_signal_connect(disp->drawing, "button_press_event",
@@ -370,36 +350,32 @@ static void init_display_window(void)
             | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON1_MOTION_MASK 
             | GDK_SCROLL_MASK );
     gtk_widget_show(disp->drawing);
-    /* get color map */
-    disp->map = gtk_widget_get_colormap(disp->drawing);
+
     /* allocate colors */
-    alloc_color(&(disp->color_bg), disp->map, 0, 0, 0);
-    alloc_color(&(disp->color_grid), disp->map, 255, 255, 255);
-    alloc_color(&disp->color_baseline, disp->map, 128, 128, 128);
+    alloc_color(&disp->color_bg, 0, 0, 0);
+    alloc_color(&disp->color_grid, 255, 255, 255);
+    alloc_color(&disp->color_baseline, 128, 128, 128);
     for(i = 0; i<16; i++) {
-        alloc_color(&(disp->color_normal[i]), disp->map, normal_colors[i][0], normal_colors[i][1], normal_colors[i][2]);
-        alloc_color(&(disp->color_selected[i]), disp->map, selected_colors[i][0], selected_colors[i][1], selected_colors[i][2]);
+        alloc_color(&(disp->color_normal[i]), normal_colors[i][0],
+                    normal_colors[i][1], normal_colors[i][2]);
+        alloc_color(&(disp->color_selected[i]), selected_colors[i][0],
+                    selected_colors[i][1], selected_colors[i][2]);
     }
 
 }
 
-static void handle_window_expose(GtkWidget * widget, gpointer data)
-{
-    /* we don't want to react immediately - sometime we get a burst of expose 
-       events - instead we request a refresh for later */
-    request_display_refresh(2);
-}
-
-void clear_display_window(void)
+/*
+ * Paints the entire widget black.
+ * This is being used as background for the oscilloscope.
+ */
+static void clear_display_window(void)
 {
     scope_disp_t *disp;
 
     disp = &(ctrl_usr->disp);
-    /* set color to draw */
-    gdk_gc_set_foreground(disp->context, &(disp->color_bg));
-    /* draw a big rectangle to clear the screen */
-    gdk_draw_rectangle(disp->win, disp->context, TRUE, 0, 0, disp->width,
-	disp->height);
+
+    gdk_cairo_set_source_rgba(disp->context, &disp->color_bg);
+    cairo_paint(disp->context);
 }
 
 void draw_grid(void)
@@ -413,7 +389,7 @@ void draw_grid(void)
 
     disp = &(ctrl_usr->disp);
     /* set color to draw */
-    gdk_gc_set_foreground(disp->context, &(disp->color_grid));
+    gdk_cairo_set_source_rgba(disp->context, &disp->color_grid);
     /* calculate scale factors */
     xscale = disp->width - 1.0;
     yscale = disp->height - 1.0;
@@ -444,12 +420,14 @@ void draw_grid(void)
 	    /* draw the major division point */
 	    x = fx * xscale;
 	    y = fy * yscale;
-	    gdk_draw_point(disp->win, disp->context, x, y);
+            cairo_rectangle(disp->context, x, y, 1, 1);
+            cairo_fill(disp->context);
 	    /* draw minor divisions (vertical) */
 	    if (ny < 10) {
 		for (m = 1; m < yminor; m++) {
 		    y = (((0.1 * m) / yminor) + fy) * yscale;
-		    gdk_draw_point(disp->win, disp->context, x, y);
+                    cairo_rectangle(disp->context, x, y, 1, 1);
+                    cairo_fill(disp->context);
 		}
 	    }
 	    /* draw minor divisions (horizontal) */
@@ -457,7 +435,8 @@ void draw_grid(void)
 		y = fy * yscale;
 		for (m = 1; m < xminor; m++) {
 		    x = (((0.1 * m) / xminor) + fx) * xscale;
-		    gdk_draw_point(disp->win, disp->context, x, y);
+                    cairo_rectangle(disp->context, x, y, 1, 1);
+                    cairo_fill(disp->context);
 		}
 	    }
 	}
@@ -564,7 +543,7 @@ static void middle_drag(int dx) {
     scope_horiz_t *horiz = &(ctrl_usr->horiz);
     double dt = (dx / disp->pixels_per_sample) / ctrl_shm->rec_len;
     set_horiz_pos(horiz->pos_setting + 5 * dt);
-    refresh_display();
+    redraw_window();
 }
 
 static double snap(int y) {
@@ -590,7 +569,7 @@ static void left_drag(int dy, int y, GdkModifierType state) {
         double new_position = snap(y);
         set_vert_pos(new_position);
         // chan->position = new_position;
-        refresh_display();
+        redraw_window();
         motion_y = y;
     } else {
         if(abs(dy) > 5) {
@@ -617,7 +596,7 @@ static int handle_motion(GtkWidget *widget, GdkEventButton *event, gpointer data
         middle_drag(motion_x - x);
     }
     motion_x = x;
-    refresh_display();
+    redraw_window();
     return TRUE;
 }
 
@@ -675,7 +654,9 @@ static double distance_point_line(int x, int y, int x1, int y1, int x2, int y2) 
 void line(int chan_num, int x1, int y1, int x2, int y2) {
     scope_disp_t *disp = &(ctrl_usr->disp);
     if(DRAWING) {
-        gdk_draw_line(disp->win, disp->context, COORDINATE_CLIP(x1), COORDINATE_CLIP(y1), COORDINATE_CLIP(x2), COORDINATE_CLIP(y2));
+        cairo_move_to(disp->context, COORDINATE_CLIP(x1), COORDINATE_CLIP(y1));
+        cairo_line_to(disp->context, COORDINATE_CLIP(x2), COORDINATE_CLIP(y2));
+        cairo_stroke(disp->context);
     } else {
         double dist = distance_point_line(select_x, select_y, x1, y1, x2, y2);
         if(dist < min_dist) {
@@ -687,10 +668,15 @@ void line(int chan_num, int x1, int y1, int x2, int y2) {
 
 void lines(int chan_num, GdkPoint points[], gint npoints) {
     double dist;
-
+    int n;
     scope_disp_t *disp = &(ctrl_usr->disp);
     if(DRAWING) {
-        gdk_draw_lines(disp->win, disp->context, points, npoints);
+        cairo_move_to(disp->context, points[0].x, points[0].y);
+        for (n = 1; n < npoints; n++) {
+            cairo_line_to(disp->context, points[n].x, points[n].y);
+        }
+        cairo_stroke(disp->context);
+
     } else {
         int x1 = points[0].x, y1 = points[0].y, x2, y2, i;
         for(i=1; i<npoints; i++) {
@@ -709,7 +695,6 @@ void lines(int chan_num, GdkPoint points[], gint npoints) {
 
 static
 void draw_triggerline(int chan_num, int highlight) {
-    static gint8 dashes[2] = {2,4};
     scope_disp_t *disp = &(ctrl_usr->disp);
     scope_chan_t *chan = &(ctrl_usr->chan[chan_num - 1]);
     scope_trig_t *trig = &(ctrl_usr->trig);
@@ -719,6 +704,9 @@ void draw_triggerline(int chan_num, int highlight) {
     double fp_level =
         chan->scale * ((chan->position - trig->level) * 10) +
 	chan->vert_offset;
+
+    const double dashes[2] = {2,4};
+    int ndash = sizeof(dashes) / sizeof(dashes[0]);
 
     int y1 = (fp_level-yfoffset) * yscale + ypoffset;
     double dx = hypot(disp->width, disp->height) * .01;
@@ -732,18 +720,18 @@ void draw_triggerline(int chan_num, int highlight) {
     if(ctrl_shm->trig_edge) dy = -dy;
 
     if(highlight) {
-	gdk_gc_set_foreground(disp->context, &(disp->color_selected[chan_num-1]));
+        gdk_cairo_set_source_rgba(disp->context, &disp->color_selected[chan_num - 1]);
     } else {
-	gdk_gc_set_foreground(disp->context, &(disp->color_normal[chan_num-1]));
+        gdk_cairo_set_source_rgba(disp->context, &disp->color_normal[chan_num - 1]);
     }
-    gdk_gc_set_dashes(disp->context, 0, dashes, 2);
-    gdk_gc_set_line_attributes(disp->context, 0, GDK_LINE_ON_OFF_DASH, GDK_CAP_BUTT, GDK_JOIN_MITER);
+    cairo_set_dash(disp->context, dashes, ndash, 0.0);
     line(chan_num | 0x200, 0, y1, disp->width, y1);
-    gdk_gc_set_line_attributes(disp->context, 0, GDK_LINE_SOLID, GDK_CAP_BUTT, GDK_JOIN_MITER);
+    /* setting ndash = 0 to disable dashing */
+    cairo_set_dash(disp->context, dashes, 0, 0.0);
     if(highlight) {
-        gdk_gc_set_foreground(disp->context, &(disp->color_grid));
+        gdk_cairo_set_source_rgba(disp->context, &disp->color_grid);
     } else {
-        gdk_gc_set_foreground(disp->context, &(disp->color_baseline));
+        gdk_cairo_set_source_rgba(disp->context, &disp->color_baseline);
     }
     line(chan_num | 0x300, 2*dx, y1, 2*dx, y1 + 2*dy);
     line(chan_num | 0x300, dx, y1+dy, 2*dx, y1 + 2*dy);
@@ -759,9 +747,9 @@ void draw_baseline(int chan_num, int highlight) {
     double yscale = disp->height / (-10.0 * chan->scale);
     int y1 = -yfoffset * yscale + ypoffset;;
     if(highlight) {
-        gdk_gc_set_foreground(disp->context, &(disp->color_grid));
+        gdk_cairo_set_source_rgba(disp->context, &disp->color_grid);
     } else {
-        gdk_gc_set_foreground(disp->context, &(disp->color_baseline));
+        gdk_cairo_set_source_rgba(disp->context, &disp->color_baseline);
     }
     line(chan_num | 0x100, 0, y1, disp->width, y1);
 }
@@ -810,9 +798,9 @@ void draw_waveform(int chan_num, int highlight)
 
     /* set color to draw */
     if (highlight) {
-	gdk_gc_set_foreground(disp->context, &(disp->color_selected[chan_num-1]));
+        gdk_cairo_set_source_rgba(disp->context, &disp->color_selected[chan_num - 1]);
     } else {
-	gdk_gc_set_foreground(disp->context, &(disp->color_normal[chan_num-1]));
+        gdk_cairo_set_source_rgba(disp->context, &disp->color_normal[chan_num - 1]);
     }
 
     x1 = y1 = 0;
@@ -879,8 +867,9 @@ void draw_waveform(int chan_num, int highlight)
             }
 	    if(first && highlight && DRAWING && x2 >= motion_x) {
 		    first = 0;
-		    gdk_draw_arc(disp->win, disp->context, TRUE,
-				x2-3, y2-3, 7, 7, 0, 360*64);
+                    cairo_arc(disp->context, x2, y2, 5, 0.0, 2.0 * M_PI);
+                    cairo_fill(disp->context);
+
                     cursor_prev_value = prev_fy;
                     cursor_value = fy;
                     cursor_time = (n - ctrl_shm->pre_trig)*horiz->sample_period;
@@ -920,7 +909,8 @@ void draw_waveform(int chan_num, int highlight)
                 y = ypoffset;
 
             conflict_avoid(&y, h);
-            gdk_draw_layout(disp->win, disp->context, 5, y, p);
+            cairo_move_to(disp->context, 5, y);
+            pango_cairo_show_layout(disp->context, p);
             g_object_unref(p);
         }
     }
@@ -951,6 +941,50 @@ void conflict_avoid(int *y, int h) {
     if(abs(yd-*y) < abs(yu-*y)) *y = yd;
     else *y = yu;
     memset(conflict_map+*y, 1, h);
+}
+
+/*
+ * Function gets called every time the window size changes. It updates the
+ * variables width and height, with the new size.
+ *
+ * This function gets called with GTK signal "size-allocate".
+ */
+static void update_drawing_size(GtkWidget *widget, GdkEventConfigure *event,
+        gpointer data)
+{
+    scope_disp_t *disp;
+    disp = &(ctrl_usr->disp);
+
+    disp->width = gtk_widget_get_allocated_width(widget);
+    disp->height = gtk_widget_get_allocated_height(widget);
+}
+
+/*
+ * Function gets called when the widget (disp->drawing) is going to
+ * be drawn. Destroys the surface if it exist, then creates a new surface
+ * with correct size.
+ *
+ * This function gets called with GTK signal "realize".
+ */
+static void create_context(void)
+{
+    scope_disp_t *disp;
+    disp = &(ctrl_usr->disp);
+
+    if (disp->surface) {
+        cairo_surface_destroy(disp->surface);
+    }
+
+    disp->surface = gdk_window_create_similar_surface(
+            gtk_widget_get_window(disp->drawing),
+            CAIRO_CONTENT_COLOR, disp->width, disp->height);
+
+    disp->context = cairo_create(disp->surface);
+
+    cairo_set_source_rgb(disp->context, 0.0, 0.0, 0.0);
+    cairo_paint(disp->context);
+
+    cairo_destroy(disp->context);
 }
 
 // vim:sts=4:sw=4:et

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -187,7 +187,7 @@ void refresh_display(void)
     vert = &(ctrl_usr->vert);
     horiz = &(ctrl_usr->horiz);
     /* get window pointer */
-    disp->win = disp->drawing->window;
+    disp->win = gtk_widget_get_window(disp->drawing);
     if (disp->win == NULL) {
 	/* window isn't visible yet, do nothing */
 	printf("refresh_display(): win = NULL, bailing!\n");
@@ -222,7 +222,7 @@ void refresh_display(void)
     {
         GdkRectangle rect = {0, 0, disp->width, disp->height};
         GdkRegion *region = gdk_region_rectangle(&rect);
-        gdk_window_begin_paint_region(disp->drawing->window, region);
+        gdk_window_begin_paint_region(gtk_widget_get_window(disp->drawing), region);
         gdk_region_destroy(region);
     }
 
@@ -268,7 +268,7 @@ void refresh_display(void)
 
     update_readout();
 
-    gdk_window_end_paint(disp->drawing->window);
+    gdk_window_end_paint(gtk_widget_get_window(disp->drawing));
 }
 
 /***********************************************************************
@@ -608,7 +608,7 @@ static int handle_motion(GtkWidget *widget, GdkEventButton *event, gpointer data
     GdkModifierType mod;
     int x, y;
 
-    gdk_window_get_pointer(disp->drawing->window, &x, &y, &mod);
+    gdk_window_get_pointer(gtk_widget_get_window(disp->drawing), &x, &y, &mod);
     if(mod & GDK_BUTTON1_MASK) {
         left_drag(y-motion_y, y, event->state);
         return TRUE;

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -758,42 +758,29 @@ static void dialog_realtime_not_running(void)
     }
 }
 
-void file_ok_sel( GtkWidget        *w,
-                  GtkFileSelection *fs )
+void log_popup(GtkWindow *parent)
 {
-    //scope_log_t* log_prefs;
-    //log_prefs = &(ctrl_usr->log);
-    //log_prefs->filename = 
-    //    (char*)gtk_file_selection_get_filename (GTK_FILE_SELECTION (fs));
-    //g_print ("filename is: %s\n", log_prefs->filename); 
-    
-    write_log_file( (char*)gtk_file_selection_get_filename (GTK_FILE_SELECTION (fs)));
-    //gtk_widget_destroy( w);
-}
-
-void log_popup(int junk)
-{
-    //generic selection dialog, straight from the gtk tutorial
     GtkWidget *filew;
-    filew = gtk_file_selection_new(_("Pick log file to write to:"));
-    gtk_signal_connect (GTK_OBJECT (filew), "destroy",
-        (GtkSignalFunc) gtk_widget_destroy, &filew);
-    gtk_signal_connect (GTK_OBJECT (GTK_FILE_SELECTION (filew)->ok_button),
-                        "clicked", (GtkSignalFunc) file_ok_sel, filew );
-    //link ok to destroy, otherwise the window stays open
-    gtk_signal_connect_object (GTK_OBJECT (GTK_FILE_SELECTION
-                                            (filew)->ok_button),
-                               "clicked", (GtkSignalFunc) gtk_widget_destroy,
-                               GTK_OBJECT (filew));
-    gtk_signal_connect_object (GTK_OBJECT (GTK_FILE_SELECTION
-                                            (filew)->cancel_button),
-                               "clicked", (GtkSignalFunc) gtk_widget_destroy,
-                               GTK_OBJECT (filew));
-    gtk_file_selection_set_filename (GTK_FILE_SELECTION(filew), 
-                                     "halscope.log");
-    gtk_file_selection_hide_fileop_buttons (GTK_FILE_SELECTION(filew) );
-    gtk_widget_show(filew);
+    GtkFileChooser *chooser;
 
+    filew = gtk_file_chooser_dialog_new(_("Pick log file to write to:"),
+                                        parent, GTK_FILE_CHOOSER_ACTION_SAVE,
+                                        _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                        _("_Save"), GTK_RESPONSE_ACCEPT, NULL);
+
+    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(filew), "halscope.log");
+    chooser = GTK_FILE_CHOOSER(filew);
+    set_file_filter(chooser, "Halscope log", "*.log");
+    gtk_file_chooser_set_do_overwrite_confirmation(chooser, TRUE);
+
+    if (gtk_dialog_run(GTK_DIALOG(filew)) == GTK_RESPONSE_ACCEPT) {
+        char *filename;
+
+        filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filew));
+        write_log_file(filename);
+        g_free(filename);
+    }
+    gtk_widget_destroy(filew);
 }
 
 static void acquire_popup(GtkWidget * widget, gpointer gdata)

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -1191,7 +1191,7 @@ static gint horiz_motion(GtkWidget *widget, GdkEventMotion *event) {
 
     int motion;
 
-    int pre_trig, width;
+    int pre_trig;
     double disp_center, disp_start, disp_end;
     double rec_start, rec_end;
     double min, max, span, scale;
@@ -1200,10 +1200,9 @@ static gint horiz_motion(GtkWidget *widget, GdkEventMotion *event) {
     int x, y;
     GdkModifierType state;
 
-    if (event->is_hint)
-        gdk_window_get_pointer (event->window, &x, &y, &state);
-    else
-    {
+    if (event->is_hint) {
+        gdk_window_get_device_position(event->window, event->device, &x, &y, &state);
+    } else {
         x = event->x;
         y = event->y;
         state = event->state;
@@ -1212,8 +1211,6 @@ static gint horiz_motion(GtkWidget *widget, GdkEventMotion *event) {
     if(!(state & GDK_BUTTON1_MASK)) return TRUE;
 
     motion = x - horiz->x0;
-
-    gdk_window_get_geometry(GDK_WINDOW(horiz->disp_area), 0, 0, &width, 0, 0);
 
     pre_trig = ctrl_shm->rec_len * ctrl_usr->trig.position;
     rec_start = -pre_trig * horiz->sample_period;
@@ -1233,7 +1230,7 @@ static gint horiz_motion(GtkWidget *widget, GdkEventMotion *event) {
 	max = disp_end;
     }
     span = max - min;
-    scale = (width - 1) / span;
+    scale = (horiz->width - 1) / span;
 
     newpos = gtk_adjustment_get_value(
             GTK_ADJUSTMENT(horiz->pos_adj)) + motion * 100 / scale;

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -141,7 +141,8 @@ static void init_horiz_window(void)
     vbox = gtk_vbox_new_in_box(TRUE, 0, 0, hbox, TRUE, TRUE, 3);
     /* add a slider for zoom level */
     horiz->zoom_adj = gtk_adjustment_new(1, 1, 9, 1, 1, 0);
-    horiz->zoom_slider = gtk_hscale_new(GTK_ADJUSTMENT(horiz->zoom_adj));
+    horiz->zoom_slider = gtk_scale_new(
+            GTK_ORIENTATION_HORIZONTAL, GTK_ADJUSTMENT(horiz->zoom_adj));
     gtk_scale_set_digits(GTK_SCALE(horiz->zoom_slider), 0);
     gtk_scale_set_draw_value(GTK_SCALE(horiz->zoom_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), horiz->zoom_slider, FALSE, FALSE, 0);
@@ -153,7 +154,8 @@ static void init_horiz_window(void)
     gtk_widget_show(horiz->zoom_slider);
     /* add a slider for position control */
     horiz->pos_adj = gtk_adjustment_new(500, 0, 1000, 1, 1, 0);
-    horiz->pos_slider = gtk_hscale_new(GTK_ADJUSTMENT(horiz->pos_adj));
+    horiz->pos_slider = gtk_scale_new(
+            GTK_ORIENTATION_HORIZONTAL, GTK_ADJUSTMENT(horiz->pos_adj));
     gtk_scale_set_digits(GTK_SCALE(horiz->pos_slider), 0);
     gtk_scale_set_draw_value(GTK_SCALE(horiz->pos_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), horiz->pos_slider, FALSE, FALSE, 0);
@@ -203,7 +205,7 @@ static void init_horiz_window(void)
     gtk_widget_show(horiz->disp_area);
     /* label for state */
     gtk_vseparator_new_in_box(hbox, 3);
-    vbox = gtk_vbox_new_in_box(TRUE, 0, 0, hbox, FALSE, TRUE, 3);
+    vbox = gtk_vbox_new_in_box(FALSE, 0, 0, hbox, FALSE, TRUE, 3);
     horiz->state_label =
 	gtk_label_new_in_box(" ---- ", vbox, FALSE, FALSE, 3);
     gtk_label_size_to_fit(GTK_LABEL(horiz->state_label), " TRIGGERED ");
@@ -524,16 +526,20 @@ static void dialog_realtime_not_linked(void)
 
     /* display message */
     label = gtk_label_new(msg);
-    gtk_misc_set_padding(GTK_MISC(label), 15, 5);
+    gtk_widget_set_margin_top(label, 5);
+    gtk_widget_set_margin_bottom(label, 5);
+    gtk_widget_set_margin_start(label, 15);
+    gtk_widget_set_margin_end(label, 15);
     gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
             label, FALSE, TRUE, 0);
 
     /* a separator */
     gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
-            gtk_hseparator_new(), FALSE, FALSE , 0);
+            gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), FALSE, FALSE , 0);
 
     /* thread name display */
-    hbox = gtk_hbox_new(TRUE, 5);
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_set_homogeneous(GTK_BOX(hbox), TRUE);
     gtk_label_new_in_box(_("Thread:"), hbox, TRUE, TRUE, 0);
     horiz->thread_name_label =
 	gtk_label_new_in_box("------", hbox, TRUE, TRUE, 0);
@@ -541,7 +547,8 @@ static void dialog_realtime_not_linked(void)
             hbox, FALSE, TRUE, 0);
 
     /* sample period display */
-    hbox = gtk_hbox_new(TRUE, 5);
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_set_homogeneous(GTK_BOX(hbox), TRUE);
     gtk_label_new_in_box(_("Sample Period:"), hbox, TRUE, TRUE, 0);
     horiz->sample_period_label =
 	gtk_label_new_in_box("------", hbox, TRUE, TRUE, 0);
@@ -549,7 +556,8 @@ static void dialog_realtime_not_linked(void)
             hbox, FALSE, TRUE, 0);
 
     /* sample rate display */
-    hbox = gtk_hbox_new(TRUE, 5);
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_set_homogeneous(GTK_BOX(hbox), TRUE);
     gtk_label_new_in_box(_("Sample Rate:"), hbox, TRUE, TRUE, 0);
     horiz->sample_rate_label =
 	gtk_label_new_in_box("------", hbox, TRUE, TRUE, 0);
@@ -558,7 +566,7 @@ static void dialog_realtime_not_linked(void)
 
     /* a separator */
     gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
-            gtk_hseparator_new(), FALSE, FALSE , 0);
+            gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), FALSE, FALSE , 0);
 
     /* Create a scrolled window to display the thread list */
     scrolled_window = gtk_scrolled_window_new(NULL, NULL);
@@ -612,7 +620,8 @@ static void dialog_realtime_not_linked(void)
     rtapi_mutex_give(&(hal_data->mutex));
 
     /* set up the the layout for the multiplier spinbutton */
-    hbox = gtk_hbox_new(TRUE, 5);
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_set_homogeneous(GTK_BOX(hbox), TRUE);
     gtk_label_new_in_box(_("Multiplier:"), hbox, FALSE, FALSE, 0);
     /* set up the multiplier spinbutton - ranges from every run of the
        thread, to every 1000th run */
@@ -630,7 +639,7 @@ static void dialog_realtime_not_linked(void)
 
     /* a separator */
     gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
-            gtk_hseparator_new(), FALSE, FALSE , 0);
+            gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), FALSE, FALSE , 0);
 
     /* box for record length buttons */
     label = gtk_label_new(_("Record Length"));

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -145,8 +145,8 @@ static void init_horiz_window(void)
     /* store the current value of the slider */
     horiz->zoom_setting = GTK_ADJUSTMENT(horiz->zoom_adj)->value;
     /* connect the slider to a function that re-calcs horizontal scaling */
-    gtk_signal_connect(GTK_OBJECT(horiz->zoom_adj), "value_changed",
-	GTK_SIGNAL_FUNC(zoom_changed), NULL);
+    g_signal_connect(horiz->zoom_adj, "value_changed",
+	G_CALLBACK(zoom_changed), NULL);
     gtk_widget_show(horiz->zoom_slider);
     /* add a slider for position control */
     horiz->pos_adj = gtk_adjustment_new(500, 0, 1000, 1, 1, 0);
@@ -157,8 +157,8 @@ static void init_horiz_window(void)
     /* store the current value of the slider */
     horiz->pos_setting = GTK_ADJUSTMENT(horiz->pos_adj)->value / 1000.0;
     /* connect the slider to a function that re-calcs horizontal position */
-    gtk_signal_connect(GTK_OBJECT(horiz->pos_adj), "value_changed",
-	GTK_SIGNAL_FUNC(pos_changed), NULL);
+    g_signal_connect(horiz->pos_adj, "value_changed",
+	G_CALLBACK(pos_changed), NULL);
     gtk_widget_show(horiz->pos_slider);
     /* third column - scale display */
     horiz->scale_label = gtk_label_new_in_box("----", hbox, FALSE, FALSE, 5);
@@ -172,8 +172,8 @@ static void init_horiz_window(void)
 	"99999 Samples\nat 99.9 MHz");
     gtk_box_pack_start(GTK_BOX(hbox), horiz->record_button, FALSE, FALSE, 0);
     /* activate the acquire menu if button is clicked */
-    gtk_signal_connect(GTK_OBJECT(horiz->record_button), "clicked",
-	GTK_SIGNAL_FUNC(acquire_popup), NULL);
+    g_signal_connect(horiz->record_button, "clicked",
+	G_CALLBACK(acquire_popup), NULL);
     gtk_widget_show(horiz->record_button);
     /* lower region, graphical status display */
     gtk_hseparator_new_in_box(ctrl_usr->horiz_info_win, 0);
@@ -186,12 +186,12 @@ static void init_horiz_window(void)
 #else
     horiz->disp_area = gtk_drawing_area_new();
 #endif
-    gtk_signal_connect(GTK_OBJECT(horiz->disp_area), "button_press_event", 
-        GTK_SIGNAL_FUNC(horiz_press), 0);
-    gtk_signal_connect(GTK_OBJECT(horiz->disp_area), "button_release_event", 
-        GTK_SIGNAL_FUNC(horiz_release), 0);
-    gtk_signal_connect(GTK_OBJECT(horiz->disp_area), "motion_notify_event", 
-        GTK_SIGNAL_FUNC(horiz_motion), 0);
+    g_signal_connect(horiz->disp_area, "button_press_event",
+        G_CALLBACK(horiz_press), 0);
+    g_signal_connect(horiz->disp_area, "button_release_event",
+        G_CALLBACK(horiz_release), 0);
+    g_signal_connect(horiz->disp_area, "motion_notify_event",
+        G_CALLBACK(horiz_motion), 0);
     gtk_widget_set_events(GTK_WIDGET(horiz->disp_area),
         GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
         | GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK);
@@ -618,8 +618,8 @@ static void dialog_realtime_not_linked(void)
     gtk_box_pack_start(GTK_BOX(hbox), horiz->mult_spinbutton, FALSE, TRUE, 0);
     gtk_widget_show(horiz->mult_spinbutton);
     /* connect the multiplier spinbutton to a function */
-    gtk_signal_connect(GTK_OBJECT(horiz->mult_adj), "value_changed",
-	GTK_SIGNAL_FUNC(mult_changed), NULL);
+    g_signal_connect(horiz->mult_adj, "value_changed",
+	G_CALLBACK(mult_changed), NULL);
 
     /* a separator */
     gtk_hseparator_new_in_box(GTK_DIALOG(dialog.window)->vbox, 0);
@@ -672,16 +672,16 @@ static void dialog_realtime_not_linked(void)
     /* set the default button */
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(buttons[n]), TRUE);
     /* set up callbacks for the buttons */
-    gtk_signal_connect(GTK_OBJECT(buttons[0]), "clicked",
-	GTK_SIGNAL_FUNC(rec_len_button), (gpointer) 1);
-    gtk_signal_connect(GTK_OBJECT(buttons[1]), "clicked",
-	GTK_SIGNAL_FUNC(rec_len_button), (gpointer) 2);
-    gtk_signal_connect(GTK_OBJECT(buttons[2]), "clicked",
-	GTK_SIGNAL_FUNC(rec_len_button), (gpointer) 4);
-    gtk_signal_connect(GTK_OBJECT(buttons[3]), "clicked",
-	GTK_SIGNAL_FUNC(rec_len_button), (gpointer) 8);
-    gtk_signal_connect(GTK_OBJECT(buttons[4]), "clicked",
-	GTK_SIGNAL_FUNC(rec_len_button), (gpointer) 16);
+    g_signal_connect(buttons[0], "clicked",
+	G_CALLBACK(rec_len_button), (gpointer) 1);
+    g_signal_connect(buttons[1], "clicked",
+	G_CALLBACK(rec_len_button), (gpointer) 2);
+    g_signal_connect(buttons[2], "clicked",
+	G_CALLBACK(rec_len_button), (gpointer) 4);
+    g_signal_connect(buttons[3], "clicked",
+	G_CALLBACK(rec_len_button), (gpointer) 8);
+    g_signal_connect(buttons[4], "clicked",
+	G_CALLBACK(rec_len_button), (gpointer) 16);
 
     /* was a thread previously used? */
     if (sel_row > -1) {
@@ -689,19 +689,19 @@ static void dialog_realtime_not_linked(void)
         mark_selected_row(horiz->thread_list, sel_row);
     }
     /* set up a callback function when the window is destroyed */
-    gtk_signal_connect(GTK_OBJECT(dialog.window), "destroy",
-	GTK_SIGNAL_FUNC(dialog_generic_destroyed), &dialog);
+    g_signal_connect(dialog.window, "destroy",
+	G_CALLBACK(dialog_generic_destroyed), &dialog);
     /* make OK and Cancel buttons */
     button = gtk_button_new_with_label(_("OK"));
     gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->action_area),
 	button, TRUE, TRUE, 4);
-    gtk_signal_connect(GTK_OBJECT(button), "clicked",
-	GTK_SIGNAL_FUNC(dialog_generic_button1), &dialog);
+    g_signal_connect(button, "clicked",
+	G_CALLBACK(dialog_generic_button1), &dialog);
     button = gtk_button_new_with_label(_("Quit"));
     gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->action_area),
 	button, TRUE, TRUE, 4);
-    gtk_signal_connect(GTK_OBJECT(button), "clicked",
-	GTK_SIGNAL_FUNC(dialog_generic_button2), &dialog);
+    g_signal_connect(button, "clicked",
+	G_CALLBACK(dialog_generic_button2), &dialog);
     /* make window transient and modal */
     gtk_window_set_transient_for(GTK_WINDOW(dialog.window),
 	GTK_WINDOW(ctrl_usr->main_win));

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -503,12 +503,12 @@ static void dialog_realtime_not_linked(void)
 	msg = _("Select a thread name and multiplier then click 'OK'\n"
 	    "or\n" "Click 'Quit' to exit HALSCOPE");
     }
-    /* create dialog window, disable resizing */
+    /* create dialog window, disable resizing and set title */
     dialog.retval = 0;
     dialog.window = gtk_dialog_new();
-    gtk_window_set_policy(GTK_WINDOW(dialog.window), FALSE, FALSE, FALSE);
-    /* set title */
+    gtk_window_set_resizable(GTK_WINDOW(dialog.window), FALSE);
     gtk_window_set_title(GTK_WINDOW(dialog.window), title);
+
     /* display message */
     label = gtk_label_new(msg);
     gtk_misc_set_padding(GTK_MISC(label), 15, 5);

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -240,7 +240,8 @@ static void init_trigger_info_window(void)
     trig->level_adj =
 	gtk_adjustment_new(TRIG_LEVEL_RESOLUTION / 2, 0,
 	TRIG_LEVEL_RESOLUTION, 1, 1, 0);
-    trig->level_slider = gtk_vscale_new(GTK_ADJUSTMENT(trig->level_adj));
+    trig->level_slider = gtk_scale_new(
+            GTK_ORIENTATION_VERTICAL, GTK_ADJUSTMENT(trig->level_adj));
     gtk_scale_set_digits(GTK_SCALE(trig->level_slider), 0);
     gtk_scale_set_draw_value(GTK_SCALE(trig->level_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), trig->level_slider, TRUE, TRUE, 0);
@@ -257,7 +258,8 @@ static void init_trigger_info_window(void)
     trig->pos_adj =
 	gtk_adjustment_new(TRIG_POS_RESOLUTION / 2, 0, TRIG_POS_RESOLUTION, 1,
 	1, 0);
-    trig->pos_slider = gtk_vscale_new(GTK_ADJUSTMENT(trig->pos_adj));
+    trig->pos_slider = gtk_scale_new(
+            GTK_ORIENTATION_VERTICAL, GTK_ADJUSTMENT(trig->pos_adj));
     gtk_scale_set_digits(GTK_SCALE(trig->pos_slider), 0);
     gtk_scale_set_draw_value(GTK_SCALE(trig->pos_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), trig->pos_slider, TRUE, TRUE, 0);
@@ -317,7 +319,10 @@ static void dialog_select_trigger_source(void)
 
     /* display message */
     label = gtk_label_new(msg);
-    gtk_misc_set_padding(GTK_MISC(label), 15, 5);
+    gtk_widget_set_margin_top(label, 5);
+    gtk_widget_set_margin_bottom(label, 5);
+    gtk_widget_set_margin_start(label, 15);
+    gtk_widget_set_margin_end(label, 15);
     gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
             label, FALSE, TRUE, 0);
 

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -194,9 +194,8 @@ static void init_trigger_mode_window(void)
     ctrl_shm->auto_trig = 0;
     /* define the radio buttons */
     trig->normal_button = gtk_radio_button_new_with_label(NULL, _("Normal"));
-    trig->auto_button =
-	gtk_radio_button_new_with_label(gtk_radio_button_group
-	(GTK_RADIO_BUTTON(trig->normal_button)), _("Auto"));
+    trig->auto_button = gtk_radio_button_new_with_label_from_widget(
+        GTK_RADIO_BUTTON(trig->normal_button), _("Auto"));
     /* and a regular button */
     trig->force_button = gtk_button_new_with_label(_("Force"));
     /* now put them into the box */
@@ -207,12 +206,12 @@ static void init_trigger_mode_window(void)
     gtk_box_pack_start(GTK_BOX(ctrl_usr->trig_info_win),
 	trig->force_button, FALSE, FALSE, 0);
     /* hook callbacks to buttons */
-    gtk_signal_connect(GTK_OBJECT(trig->normal_button), "clicked",
-	GTK_SIGNAL_FUNC(normal_button_clicked), NULL);
-    gtk_signal_connect(GTK_OBJECT(trig->auto_button), "clicked",
-	GTK_SIGNAL_FUNC(auto_button_clicked), NULL);
-    gtk_signal_connect(GTK_OBJECT(trig->force_button), "clicked",
-	GTK_SIGNAL_FUNC(force_button_clicked), NULL);
+    g_signal_connect(trig->normal_button, "clicked",
+	G_CALLBACK(normal_button_clicked), NULL);
+    g_signal_connect(trig->auto_button, "clicked",
+	G_CALLBACK(auto_button_clicked), NULL);
+    g_signal_connect(trig->force_button, "clicked",
+	G_CALLBACK(force_button_clicked), NULL);
     /* and make them visible */
     gtk_widget_show(trig->normal_button);
     gtk_widget_show(trig->auto_button);

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -248,8 +248,8 @@ static void init_trigger_info_window(void)
     trig->level =
 	(GTK_ADJUSTMENT(trig->level_adj))->value / TRIG_LEVEL_RESOLUTION;
     /* connect the slider to a function that re-sets the trigger level */
-    gtk_signal_connect(GTK_OBJECT(trig->level_adj), "value_changed",
-	GTK_SIGNAL_FUNC(level_changed), NULL);
+    g_signal_connect(trig->level_adj, "value_changed",
+	G_CALLBACK(level_changed), NULL);
     gtk_widget_show(trig->level_slider);
     /* box for the position slider */
     vbox = gtk_vbox_new_in_box(FALSE, 0, 0, hbox, TRUE, TRUE, 0);
@@ -265,8 +265,8 @@ static void init_trigger_info_window(void)
     trig->position =
 	(GTK_ADJUSTMENT(trig->pos_adj))->value / TRIG_POS_RESOLUTION;
     /* connect the slider to a function that re-sets trigger position */
-    gtk_signal_connect(GTK_OBJECT(trig->pos_adj), "value_changed",
-	GTK_SIGNAL_FUNC(pos_changed), NULL);
+    g_signal_connect(trig->pos_adj, "value_changed",
+	G_CALLBACK(pos_changed), NULL);
     gtk_widget_show(trig->pos_slider);
     /* level display */
     gtk_hseparator_new_in_box(ctrl_usr->trig_info_win, 3);
@@ -280,16 +280,16 @@ static void init_trigger_info_window(void)
     trig->edge_label = (GTK_BIN(trig->edge_button))->child;
     gtk_box_pack_start(GTK_BOX(ctrl_usr->trig_info_win),
 	trig->edge_button, FALSE, FALSE, 0);
-    gtk_signal_connect(GTK_OBJECT(trig->edge_button), "clicked",
-	GTK_SIGNAL_FUNC(edge_button_clicked), NULL);
+    g_signal_connect(trig->edge_button, "clicked",
+	G_CALLBACK(edge_button_clicked), NULL);
     gtk_widget_show(trig->edge_button);
     /* define a button to set the trigger source */
     trig->source_button = gtk_button_new_with_label(_("Source\nNone"));
     trig->source_label = (GTK_BIN(trig->source_button))->child;
     gtk_box_pack_start(GTK_BOX(ctrl_usr->trig_info_win),
 	trig->source_button, FALSE, FALSE, 0);
-    gtk_signal_connect(GTK_OBJECT(trig->source_button), "clicked",
-	GTK_SIGNAL_FUNC(source_button_clicked), NULL);
+    g_signal_connect(trig->source_button, "clicked",
+	G_CALLBACK(source_button_clicked), NULL);
     gtk_widget_show(trig->source_button);
 }
 
@@ -354,14 +354,14 @@ static void dialog_select_trigger_source(void)
         mark_selected_row(trig_list, ctrl_shm->trig_chan - 1);
     }
     /* set up a callback function when the window is destroyed */
-    gtk_signal_connect(GTK_OBJECT(dialog.window), "destroy",
-	GTK_SIGNAL_FUNC(dialog_generic_destroyed), &dialog);
+    g_signal_connect(dialog.window, "destroy",
+	G_CALLBACK(dialog_generic_destroyed), &dialog);
     /* make Cancel button */
     button = gtk_button_new_with_label(_("Cancel"));
     gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->action_area),
 	button, TRUE, TRUE, 4);
-    gtk_signal_connect(GTK_OBJECT(button), "clicked",
-	GTK_SIGNAL_FUNC(dialog_generic_button2), &dialog);
+    g_signal_connect(button, "clicked",
+	G_CALLBACK(dialog_generic_button2), &dialog);
     /* make window transient and modal */
     gtk_window_set_transient_for(GTK_WINDOW(dialog.window),
 	GTK_WINDOW(ctrl_usr->main_win));

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -168,7 +168,7 @@ void refresh_trigger(void)
         gtk_widget_set_sensitive(GTK_WIDGET(trig->level_slider), 1);
     }
     gtk_label_set_text_if(trig->level_label, buf);
-    refresh_display();
+    redraw_window();
 }
 
 void write_trig_config(FILE *fp)

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -301,15 +301,13 @@ static void dialog_select_trigger_source(void)
     if (ctrl_shm->state != IDLE) { prepare_scope_restart(); }
     title = _("Trigger Source");
     msg = _("Select a channel to use for triggering.");
-    /* create dialog window, disable resizing */
+
+    /* create dialog window, disable resizing, set size and title */
     dialog.retval = 0;
     dialog.window = gtk_dialog_new();
-    /* set initial height of window */
-    gtk_widget_set_usize(GTK_WIDGET(dialog.window), -2, 400);
-    /* allow user to grow but not shrink the window */
-    gtk_window_set_policy(GTK_WINDOW(dialog.window), FALSE, TRUE, FALSE);
-    /* set title */
+    gtk_widget_set_size_request(GTK_WIDGET(dialog.window), -1, 400);
     gtk_window_set_title(GTK_WINDOW(dialog.window), title);
+
     /* display message */
     label = gtk_label_new(msg);
     gtk_misc_set_padding(GTK_MISC(label), 15, 5);

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -245,8 +245,8 @@ static void init_trigger_info_window(void)
     gtk_scale_set_draw_value(GTK_SCALE(trig->level_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), trig->level_slider, TRUE, TRUE, 0);
     /* set initial trigger level */
-    trig->level =
-	(GTK_ADJUSTMENT(trig->level_adj))->value / TRIG_LEVEL_RESOLUTION;
+    trig->level = gtk_adjustment_get_value(
+            GTK_ADJUSTMENT(trig->level_adj)) / TRIG_LEVEL_RESOLUTION;
     /* connect the slider to a function that re-sets the trigger level */
     g_signal_connect(trig->level_adj, "value_changed",
 	G_CALLBACK(level_changed), NULL);
@@ -262,8 +262,8 @@ static void init_trigger_info_window(void)
     gtk_scale_set_draw_value(GTK_SCALE(trig->pos_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), trig->pos_slider, TRUE, TRUE, 0);
     /* set initial trigger position */
-    trig->position =
-	(GTK_ADJUSTMENT(trig->pos_adj))->value / TRIG_POS_RESOLUTION;
+    trig->position = gtk_adjustment_get_value(
+            GTK_ADJUSTMENT(trig->pos_adj)) / TRIG_POS_RESOLUTION;
     /* connect the slider to a function that re-sets trigger position */
     g_signal_connect(trig->pos_adj, "value_changed",
 	G_CALLBACK(pos_changed), NULL);
@@ -277,7 +277,7 @@ static void init_trigger_info_window(void)
     /* define a button to set the trigger edge */
     ctrl_shm->trig_edge = 1;
     trig->edge_button = gtk_button_new_with_label(_("Rising"));
-    trig->edge_label = (GTK_BIN(trig->edge_button))->child;
+    trig->edge_label = gtk_bin_get_child(GTK_BIN(trig->edge_button));
     gtk_box_pack_start(GTK_BOX(ctrl_usr->trig_info_win),
 	trig->edge_button, FALSE, FALSE, 0);
     g_signal_connect(trig->edge_button, "clicked",
@@ -285,7 +285,7 @@ static void init_trigger_info_window(void)
     gtk_widget_show(trig->edge_button);
     /* define a button to set the trigger source */
     trig->source_button = gtk_button_new_with_label(_("Source\nNone"));
-    trig->source_label = (GTK_BIN(trig->source_button))->child;
+    trig->source_label = gtk_bin_get_child(GTK_BIN(trig->source_button));
     gtk_box_pack_start(GTK_BOX(ctrl_usr->trig_info_win),
 	trig->source_button, FALSE, FALSE, 0);
     g_signal_connect(trig->source_button, "clicked",
@@ -301,6 +301,7 @@ static void dialog_select_trigger_source(void)
     gchar *strs[2], *titles[NUM_COLS];
     gchar buf[BUFLEN + 1];
     GtkWidget *label, *button, *scrolled_window, *trig_list;
+    GtkWidget *content_area;
 
     /* is acquisition in progress? */
     if (ctrl_shm->state != IDLE) { prepare_scope_restart(); }
@@ -312,19 +313,20 @@ static void dialog_select_trigger_source(void)
     dialog.window = gtk_dialog_new();
     gtk_widget_set_size_request(GTK_WIDGET(dialog.window), -1, 400);
     gtk_window_set_title(GTK_WINDOW(dialog.window), title);
+    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog.window));
 
     /* display message */
     label = gtk_label_new(msg);
     gtk_misc_set_padding(GTK_MISC(label), 15, 5);
-    gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->vbox), label, FALSE,
-	TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
+            label, FALSE, TRUE, 0);
+
     /* Create a scrolled window to display the list */
     scrolled_window = gtk_scrolled_window_new(NULL, NULL);
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_window),
 	GTK_POLICY_AUTOMATIC, GTK_POLICY_ALWAYS);
-    gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->vbox),
-	scrolled_window, TRUE, TRUE, 5);
-    gtk_widget_show(scrolled_window);
+    gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
+            scrolled_window, TRUE, TRUE, 5);
 
     /* create a list to hold the data */
     titles[0] = _("Chan");
@@ -358,8 +360,8 @@ static void dialog_select_trigger_source(void)
 	G_CALLBACK(dialog_generic_destroyed), &dialog);
     /* make Cancel button */
     button = gtk_button_new_with_label(_("Cancel"));
-    gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->action_area),
-	button, TRUE, TRUE, 4);
+    gtk_dialog_add_action_widget(GTK_DIALOG(dialog.window),
+            button, 2);
     g_signal_connect(button, "clicked",
 	G_CALLBACK(dialog_generic_button2), &dialog);
     /* make window transient and modal */
@@ -427,7 +429,7 @@ int set_trigger_level(double setting)
 
 static void level_changed(GtkAdjustment * adj, gpointer gdata)
 {
-    set_trigger_level(adj->value / TRIG_LEVEL_RESOLUTION);
+    set_trigger_level(gtk_adjustment_get_value(adj) / TRIG_LEVEL_RESOLUTION);
 }
 
 int set_trigger_pos(double setting)
@@ -457,7 +459,7 @@ int set_trigger_pos(double setting)
 
 static void pos_changed(GtkAdjustment * adj, gpointer gdata)
 {
-    set_trigger_pos(adj->value / TRIG_POS_RESOLUTION);
+    set_trigger_pos(gtk_adjustment_get_value(adj) / TRIG_POS_RESOLUTION);
 }
 
 int set_trigger_polarity(int setting)

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -103,6 +103,7 @@ typedef struct {
     int chan_enabled[16];	/* chans user wants to display */
     int data_offset[16];	/* offset within sample, -1 if no data */
     int selected;		/* channel user has selected */
+    int listnum;                /* 0 = pin, 1 = signal, 2 = parameter */
     /* widgets for chan sel window */
     GtkWidget *chan_sel_buttons[16];
     /* widgets for chan info window */
@@ -123,8 +124,7 @@ typedef struct {
     GtkWidget *offset_ac;
     /* widgets for source selection dialog */
     GtkWidget *lists[3];	/* lists for pins, signals, and params */
-    GtkWidget *windows[3];	/* scrolled windows for above lists */
-    GtkAdjustment *adjs[3];	/* scrollbars associated with above */
+    GtkWidget *notebook;        /* pointer to the notebook */
 } scope_vert_t;
 
 /* this struct holds control data related to triggering */

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -104,6 +104,7 @@ typedef struct {
     int data_offset[16];	/* offset within sample, -1 if no data */
     int selected;		/* channel user has selected */
     int listnum;                /* 0 = pin, 1 = signal, 2 = parameter */
+    int chan_num;
     /* widgets for chan sel window */
     GtkWidget *chan_sel_buttons[16];
     /* widgets for chan info window */

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -66,16 +66,16 @@ typedef struct {
     GtkWidget *record_button;
     GtkWidget *record_label;
     GtkWidget *zoom_slider;
-    GtkObject *zoom_adj;
+    GtkAdjustment *zoom_adj;
     GtkWidget *pos_slider;
-    GtkObject *pos_adj;
+    GtkAdjustment *pos_adj;
     GtkWidget *scale_label;
     /* widgets for thread selection dialog */
     GtkWidget *thread_list;
     GtkWidget *thread_name_label;
     GtkWidget *sample_rate_label;
     GtkWidget *sample_period_label;
-    GtkObject *mult_adj;
+    GtkAdjustment *mult_adj;
     GtkWidget *mult_spinbutton;
 } scope_horiz_t;
 
@@ -116,10 +116,10 @@ typedef struct {
     GtkWidget *source_name_button;
     /* widgets for vert info window */
     GtkWidget *scale_slider;
-    GtkObject *scale_adj;
+    GtkAdjustment *scale_adj;
     GtkWidget *scale_label;
     GtkWidget *pos_slider;
-    GtkObject *pos_adj;
+    GtkAdjustment *pos_adj;
     GtkWidget *offset_button;
     GtkWidget *offset_label;
     GtkWidget *readout_label;
@@ -148,10 +148,10 @@ typedef struct {
     GtkWidget *edge_button;
     GtkWidget *edge_label;
     GtkWidget *level_slider;
-    GtkObject *level_adj;
+    GtkAdjustment *level_adj;
     GtkWidget *level_label;
     GtkWidget *pos_slider;
-    GtkObject *pos_adj;
+    GtkAdjustment *pos_adj;
 } scope_trig_t;
 
 
@@ -299,4 +299,4 @@ int set_trigger_mode(int mode);
 int set_run_mode(int mode);
 void prepare_scope_restart(void);
 void log_popup(GtkWindow *parent);
-#endif /* HALSC_USR_H */
+#endif /* SCOPE_USR_H */

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -56,9 +56,12 @@ typedef struct {
     int zoom_setting;		/* setting of zoom slider (1-9) */
     double pos_setting;		/* setting of position slider (0.0-1.0) */
     long x0;
+    int width;			/* width in pixels */
+    int height;			/* height in pixels */
     /* widgets for main window */
     GtkWidget *disp_area;
-    GdkGC *disp_context;
+    cairo_t *disp_context;
+    cairo_surface_t *surface;
     GtkWidget *state_label;
     GtkWidget *record_button;
     GtkWidget *record_label;

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -165,7 +165,7 @@ typedef struct {
     int end_sample;		/* last displayable sample */
     /* widgets */
     GtkWidget *drawing;		/* drawing area for display */
-    GtkTooltips *tip;		/* drawing area for display */
+    GtkTooltip *tip;		/* drawing area for display */
     /* drawing objects (GDK) */
     GdkDrawable *win;		/* the window */
     GdkColormap *map;		/* the colormap for the window */

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -295,5 +295,5 @@ int set_trigger_polarity(int setting);
 int set_trigger_mode(int mode);
 int set_run_mode(int mode);
 void prepare_scope_restart(void);
-void log_popup(int);
+void log_popup(GtkWindow *parent);
 #endif /* HALSC_USR_H */

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -161,8 +161,8 @@ typedef struct {
 
 typedef struct {
     /* general data */
-    int width;			/* height in pixels */
-    int height;			/* width in pixels */
+    int width;                  /* width in pixels */
+    int height;                 /* height in pixels */
     double pixels_per_sample;	/* horizontal scaling */
     double horiz_offset;		/* offset in pixels */
     int start_sample;		/* first displayable sample */
@@ -171,15 +171,14 @@ typedef struct {
     GtkWidget *drawing;		/* drawing area for display */
     GtkTooltip *tip;		/* drawing area for display */
     /* drawing objects (GDK) */
-    GdkDrawable *win;		/* the window */
-    GdkColormap *map;		/* the colormap for the window */
-    GdkColor color_bg;		/* background color */
-    GdkColor color_grid;	/* the grid color */
-    GdkColor color_normal[16];	/* the color for normal waveforms */
-    GdkColor color_selected[16];	/* the color for selected waveforms */
-    GdkColor color_baseline;    /* The baseline color */
+    GdkRGBA color_bg;           /* background color */
+    GdkRGBA color_grid;         /* the grid color */
+    GdkRGBA color_normal[16];   /* the color for normal waveforms */
+    GdkRGBA color_selected[16]; /* the color for selected waveforms */
+    GdkRGBA color_baseline;     /* The baseline color */
 
-    GdkGC *context;		/* graphics context for drawing */
+    cairo_surface_t *surface;
+    cairo_t *context;
     int selected_part;
 } scope_disp_t;
 
@@ -263,7 +262,7 @@ void refresh_trigger(void);
 void invalidate_channel(int chan);
 void invalidate_all_channels(void);
 void channel_changed(void);
-
+void redraw_window(void);
 
 void format_signal_value(char *buf, int buflen, double value);
 

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -602,7 +602,6 @@ static void init_chan_info_window(void)
 
     vert->readout_label = gtk_label_new_in_box("",
 		    ctrl_usr->chan_info_win, FALSE, FALSE, 0);
-    gtk_misc_set_alignment(GTK_MISC(vert->readout_label), 0, 0);
     gtk_label_set_justify(GTK_LABEL(vert->readout_label), GTK_JUSTIFY_LEFT);
     gtk_label_size_to_fit(GTK_LABEL(vert->readout_label),
 		    "f(99999.9999) = 99999.9999 (ddt 99999.9999)");
@@ -1140,8 +1139,6 @@ void channel_changed(void)
     gtk_adjustment_set_lower(adj, chan->min_index);
     gtk_adjustment_set_upper(adj, chan->max_index);
     gtk_adjustment_set_value(adj, chan->scale_index);
-    gtk_adjustment_changed(adj);
-    gtk_adjustment_value_changed(adj);
     /* update the channel number and name display */
     snprintf(buf1, BUFLEN, "%2d", vert->selected);
     name = chan->name;

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -561,8 +561,8 @@ static void init_chan_sel_window(void)
 	    TRUE, 0);
 	gtk_widget_show(button);
 	/* hook a callback function to it */
-	gtk_signal_connect(GTK_OBJECT(button), "clicked",
-	    GTK_SIGNAL_FUNC(chan_sel_button), (gpointer) n + 1);
+	g_signal_connect(button, "clicked",
+	    G_CALLBACK(chan_sel_button), (gpointer) n + 1);
 	/* save the button pointer */
 	vert->chan_sel_buttons[n] = button;
     }
@@ -594,8 +594,8 @@ static void init_chan_info_window(void)
     dummyname[n] = '\0';
     gtk_label_size_to_fit(GTK_LABEL(vert->source_name_label), dummyname);
     /* activate the source selection dialog if button is clicked */
-    gtk_signal_connect(GTK_OBJECT(vert->source_name_button), "clicked",
-	GTK_SIGNAL_FUNC(change_source_button), NULL);
+    g_signal_connect(vert->source_name_button, "clicked",
+	G_CALLBACK(change_source_button), NULL);
     gtk_widget_show(vert->source_name_button);
 
 
@@ -628,8 +628,8 @@ static void init_vert_info_window(void)
     gtk_scale_set_draw_value(GTK_SCALE(vert->scale_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), vert->scale_slider, TRUE, TRUE, 0);
     /* connect the slider to a function that re-calcs vertical scale */
-    gtk_signal_connect(GTK_OBJECT(vert->scale_adj), "value_changed",
-	GTK_SIGNAL_FUNC(scale_changed), NULL);
+    g_signal_connect(vert->scale_adj, "value_changed",
+	G_CALLBACK(scale_changed), NULL);
     gtk_widget_show(vert->scale_slider);
     /* box for the position slider */
     vbox = gtk_vbox_new_in_box(FALSE, 0, 0, hbox, TRUE, TRUE, 0);
@@ -642,8 +642,8 @@ static void init_vert_info_window(void)
     gtk_scale_set_draw_value(GTK_SCALE(vert->pos_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), vert->pos_slider, TRUE, TRUE, 0);
     /* connect the slider to a function that re-calcs vertical pos */
-    gtk_signal_connect(GTK_OBJECT(vert->pos_adj), "value_changed",
-	GTK_SIGNAL_FUNC(pos_changed), NULL);
+    g_signal_connect(vert->pos_adj, "value_changed",
+	G_CALLBACK(pos_changed), NULL);
     gtk_widget_show(vert->pos_slider);
     /* Scale display */
     gtk_hseparator_new_in_box(ctrl_usr->vert_info_win, 3);
@@ -656,16 +656,16 @@ static void init_vert_info_window(void)
     vert->offset_label = (GTK_BIN(vert->offset_button))->child;
     gtk_box_pack_start(GTK_BOX(ctrl_usr->vert_info_win),
 	vert->offset_button, FALSE, FALSE, 0);
-    gtk_signal_connect(GTK_OBJECT(vert->offset_button), "clicked",
-	GTK_SIGNAL_FUNC(offset_button), NULL);
+    g_signal_connect(vert->offset_button, "clicked",
+	G_CALLBACK(offset_button), NULL);
     gtk_widget_show(vert->offset_button);
     /* a button to turn off the channel */
     button = gtk_button_new_with_label(_("Chan Off"));
     gtk_box_pack_start(GTK_BOX(ctrl_usr->vert_info_win), button, FALSE, FALSE,
 	0);
     /* turn off the channel if button is clicked */
-    gtk_signal_connect(GTK_OBJECT(button), "clicked",
-	GTK_SIGNAL_FUNC(channel_off_button), NULL);
+    g_signal_connect(button, "clicked",
+	G_CALLBACK(channel_off_button), NULL);
     gtk_widget_show(button);
 }
 
@@ -739,8 +739,8 @@ static gboolean dialog_set_offset(int chan_num)
     gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->vbox),
         vert->offset_ac, FALSE, TRUE, 0);
     /* react to changes to the checkbox */
-    gtk_signal_connect(GTK_OBJECT(vert->offset_ac), "toggled",
-	GTK_SIGNAL_FUNC(offset_changed), &data);
+    g_signal_connect(vert->offset_ac, "toggled",
+	G_CALLBACK(offset_changed), &data);
     /* the entry */
     vert->offset_entry = gtk_entry_new();
     gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->vbox),
@@ -756,25 +756,25 @@ static gboolean dialog_set_offset(int chan_num)
     gtk_widget_grab_focus(GTK_WIDGET(vert->offset_entry));
     gtk_widget_show(vert->offset_entry);
     /* capture entry data to the buffer whenever the user types */
-    gtk_signal_connect(GTK_OBJECT(vert->offset_entry), "changed",
-	GTK_SIGNAL_FUNC(offset_changed), data.buf);
+    g_signal_connect(GTK_OBJECT(vert->offset_entry), "changed",
+	G_CALLBACK(offset_changed), data.buf);
     /* set up a callback function when the window is destroyed */
-    gtk_signal_connect(GTK_OBJECT(dialog.window), "destroy",
-	GTK_SIGNAL_FUNC(dialog_generic_destroyed), &dialog);
+    g_signal_connect(GTK_OBJECT(dialog.window), "destroy",
+	G_CALLBACK(dialog_generic_destroyed), &dialog);
     /* make OK and Cancel buttons */
     button = gtk_button_new_with_label(_("OK"));
     gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->action_area),
 	button, TRUE, TRUE, 4);
-    gtk_signal_connect(GTK_OBJECT(button), "clicked",
-	GTK_SIGNAL_FUNC(dialog_generic_button1), &dialog);
+    g_signal_connect(button, "clicked",
+	G_CALLBACK(dialog_generic_button1), &dialog);
     /* hit the "OK" button if the user hits enter */
-    gtk_signal_connect(GTK_OBJECT(vert->offset_entry), "activate",
-	GTK_SIGNAL_FUNC(offset_activated), button);
+    g_signal_connect(vert->offset_entry, "activate",
+	G_CALLBACK(offset_activated), button);
     button = gtk_button_new_with_label(_("Cancel"));
     gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog.window)->action_area),
 	button, TRUE, TRUE, 4);
-    gtk_signal_connect(GTK_OBJECT(button), "clicked",
-	GTK_SIGNAL_FUNC(dialog_generic_button2), &dialog);
+    g_signal_connect(button, "clicked",
+	G_CALLBACK(dialog_generic_button2), &dialog);
     /* make window transient and modal */
     gtk_window_set_transient_for(GTK_WINDOW(dialog.window),
 	GTK_WINDOW(ctrl_usr->main_win));

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -606,7 +606,8 @@ static void init_vert_info_window(void)
     vbox = gtk_vbox_new_in_box(FALSE, 0, 0, hbox, TRUE, TRUE, 0);
     gtk_label_new_in_box(_("Gain"), vbox, FALSE, FALSE, 0);
     vert->scale_adj = gtk_adjustment_new(0, -5, 5, 1, 1, 0);
-    vert->scale_slider = gtk_vscale_new(GTK_ADJUSTMENT(vert->scale_adj));
+    vert->scale_slider = gtk_scale_new(
+            GTK_ORIENTATION_VERTICAL, GTK_ADJUSTMENT(vert->scale_adj));
     gtk_scale_set_digits(GTK_SCALE(vert->scale_slider), 0);
     gtk_scale_set_draw_value(GTK_SCALE(vert->scale_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), vert->scale_slider, TRUE, TRUE, 0);
@@ -620,7 +621,8 @@ static void init_vert_info_window(void)
     vert->pos_adj =
 	gtk_adjustment_new(VERT_POS_RESOLUTION / 2, 0, VERT_POS_RESOLUTION, 1,
 	1, 0);
-    vert->pos_slider = gtk_vscale_new(GTK_ADJUSTMENT(vert->pos_adj));
+    vert->pos_slider = gtk_scale_new(
+            GTK_ORIENTATION_VERTICAL, GTK_ADJUSTMENT(vert->pos_adj));
     gtk_scale_set_digits(GTK_SCALE(vert->pos_slider), 0);
     gtk_scale_set_draw_value(GTK_SCALE(vert->pos_slider), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), vert->pos_slider, TRUE, TRUE, 0);
@@ -714,13 +716,16 @@ static gboolean dialog_set_offset(int chan_num)
 
     /* display message */
     label = gtk_label_new(msg);
-    gtk_misc_set_padding(GTK_MISC(label), 15, 5);
+    gtk_widget_set_margin_top(label, 5);
+    gtk_widget_set_margin_bottom(label, 5);
+    gtk_widget_set_margin_start(label, 15);
+    gtk_widget_set_margin_end(label, 15);
     gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
             label, FALSE, TRUE, 0);
 
     /* a separator */
     gtk_box_pack_start(GTK_BOX(GTK_CONTAINER(content_area)),
-            gtk_hseparator_new(), FALSE, FALSE, 0);
+            gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), FALSE, FALSE, 0);
 
     /* a checkbox: AC coupled */
     vert->offset_ac = gtk_check_button_new_with_label(_("AC Coupled"));

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -749,9 +749,9 @@ static gboolean dialog_set_offset(int chan_num)
     gtk_entry_set_text(GTK_ENTRY(vert->offset_entry), data.buf);
     gtk_entry_set_max_length(GTK_ENTRY(vert->offset_entry), BUFLEN-1);
     /* point at first char */
-    gtk_entry_set_position(GTK_ENTRY(vert->offset_entry), 0);
+    gtk_editable_set_position(GTK_EDITABLE(vert->offset_entry), 0);
     /* select all chars, so if the user types the original value goes away */
-    gtk_entry_select_region(GTK_ENTRY(vert->offset_entry), 0, strlen(data.buf));
+    gtk_editable_select_region(GTK_EDITABLE(vert->offset_entry), 0, strlen(data.buf));
     /* make it active so user doesn't have to click on it */
     gtk_widget_grab_focus(GTK_WIDGET(vert->offset_entry));
     gtk_widget_show(vert->offset_entry);
@@ -802,7 +802,7 @@ static void offset_changed(GtkEditable * editable, struct offset_data *data)
     /* maybe user hit "ac coupled" button" */
     data->ac_coupled =
       gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ctrl_usr->vert.offset_ac));
-    gtk_entry_set_editable(GTK_ENTRY(ctrl_usr->vert.offset_entry),
+    gtk_editable_set_editable(GTK_EDITABLE(ctrl_usr->vert.offset_entry),
                 !data->ac_coupled);
 
     /* maybe user typed something, save it in the buffer */

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -719,8 +719,6 @@ static gboolean dialog_set_offset(int chan_num)
     dialog.retval = 0;
     dialog.window = gtk_dialog_new();
     dialog.app_data = &data;
-    /* allow user to grow but not shrink the window */
-    gtk_window_set_policy(GTK_WINDOW(dialog.window), FALSE, TRUE, FALSE);
     /* window should appear in center of screen */
     gtk_window_set_position(GTK_WINDOW(dialog.window), GTK_WIN_POS_CENTER);
     /* set title */
@@ -1032,14 +1030,12 @@ static gboolean dialog_select_source(int chan_num)
     dialog.retval = 0;
     dialog.window = gtk_dialog_new();
     dialog.app_data = &chan_num;
-    /* set initial height of window */
-    gtk_widget_set_usize(GTK_WIDGET(dialog.window), -2, 300);
-    /* allow user to grow but not shrink the window */
-    gtk_window_set_policy(GTK_WINDOW(dialog.window), FALSE, TRUE, FALSE);
+    /* set size and title of window */
+    gtk_widget_set_size_request(GTK_WIDGET(dialog.window), -1, 300);
+    gtk_window_set_title(GTK_WINDOW(dialog.window), title);
     /* window should appear in center of screen */
     gtk_window_set_position(GTK_WINDOW(dialog.window), GTK_WIN_POS_CENTER);
-    /* set title */
-    gtk_window_set_title(GTK_WINDOW(dialog.window), title);
+
     /* display message */
     label = gtk_label_new(msg);
     gtk_misc_set_padding(GTK_MISC(label), 15, 5);


### PR DESCRIPTION
Replaces deprecated functions. The new version works with GTK 2 and
GTK 3, the previous version was written for GTK 1.2

The most significant change is that TreeView has replaced CList.

If the change is approved I would appreciate if it went into the LinuxCNC master branch as well.

This should resolve part of the issue in linuxcnc/linuxcnc#864