### PR TITLE
Cmake updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,12 +96,6 @@ add_compile_definitions(
         EMC2_VERSION="3.0.0"
         PACKAGE_VERSION="3.0.0"
         HAVE_READLINE
-        SEQUENTIAL_SUPPORT
-        HAL_SUPPORT
-        DYNAMIC_PLCSIZE
-        RT_SUPPORT
-        OLD_TIMERS_MONOS_SUPPORT
-        MODBUS_IO_MASTER
 )
 
 if(NOT ${BUILD_UDEV})

--- a/cmake/pythonBinary.cmake
+++ b/cmake/pythonBinary.cmake
@@ -1,0 +1,15 @@
+function(python_binary src)
+    get_filename_component(SRC_NAME ${src} NAME_WE)
+    set(SRC ${CMAKE_CURRENT_SOURCE_DIR}/${src})
+    set(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${SRC_NAME})
+
+    add_custom_target(${SRC_NAME} DEPENDS ${OUTPUT})
+    add_custom_command(
+            OUTPUT ${OUTPUT}
+            COMMAND ${Python3_EXECUTABLE} -m py_compile ${SRC}
+            COMMENT "Syntax checking Python script ${src}"
+            COMMAND ${CMAKE_COMMAND} -E copy ${SRC} ${OUTPUT}
+            COMMAND chmod 755 ${OUTPUT}
+            DEPENDS ${SRC} ${Python3_EXECUTABLE}
+    )
+endfunction()

--- a/src/emc/tooldata/CMakeLists.txt
+++ b/src/emc/tooldata/CMakeLists.txt
@@ -10,9 +10,11 @@ set_property(TARGET emc_tooldata PROPERTY POSITION_INDEPENDENT_CODE ON)
 if(${TOOL_NML})
     target_sources(emc_tooldata PRIVATE
             tooldata_nml.cc
-            )
+    )
 else()
-	#    message(FATAL_ERROR "unimplemented, please use nml.")
+    target_sources(emc_tooldata PRIVATE
+            tooldata_mmap.cc
+    )
 endif()
 
 add_executable(tooldata_watch tool_watch.cc)

--- a/src/hal/classicladder/CMakeLists.txt
+++ b/src/hal/classicladder/CMakeLists.txt
@@ -1,5 +1,3 @@
-if(USE_GTK2)
-
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CLASSICLADDER_SOURCES
@@ -9,11 +7,11 @@ set(CLASSICLADDER_SOURCES
         calc_sequential.c
         classicladder.c
         classicladder_gtk.c
-        config.c
         config_gtk.c
         drawing.c
         drawing_sequential.c
         edit.c
+        edit_copy.c
         edit_gtk.c
         edit_sequential.c
         editproperties_gtk.c
@@ -23,6 +21,8 @@ set(CLASSICLADDER_SOURCES
         files_sequential.c
         manager.c
         manager_gtk.c
+        menu_and_toolbar_gtk.c
+        print_gtk.c
         protocol_modbus_master.c
         protocol_modbus_slave.c
         serial_linux.c
@@ -31,18 +31,66 @@ set(CLASSICLADDER_SOURCES
         spy_vars_gtk.c
         symbols.c
         symbols_gtk.c
-        vars_names.c
         vars_access.c
-        )
+        vars_names.c
+)
+
+add_compile_definitions(
+        DYNAMIC_PLCSIZE
+        HAL_SUPPORT
+        MODBUS_IO_MASTER
+        OLD_TIMERS_MONOS_SUPPORT
+        RT_SUPPORT
+        SEQUENTIAL_SUPPORT
+)
 
 add_executable(classicladder ${CLASSICLADDER_SOURCES})
-target_include_directories(classicladder PRIVATE ${GTK2_INCLUDE_DIRS})
-target_include_directories(classicladder PRIVATE ${Intl_INCLUDE_DIRS})
-target_link_libraries(classicladder PRIVATE hal)
-target_link_libraries(classicladder PRIVATE Threads::Threads)
-target_link_libraries(classicladder PRIVATE ${GTK2_LIBRARIES})
-target_link_libraries(classicladder PRIVATE ${Intl_LIBRARIES})
-target_compile_definitions(classicladder PRIVATE GTK_INTERFACE GTK2)
+target_include_directories(classicladder
+        PRIVATE
+        ${GTK3_INCLUDE_DIRS}
+        ${Intl_INCLUDE_DIRS}
+)
+target_link_libraries(classicladder
+        PRIVATE
+        hal
+        Threads::Threads
+        ${GTK3_LIBRARIES}
+        ${Intl_LIBRARIES}
+)
+target_compile_definitions(classicladder
+        PRIVATE
+        GTK_INTERFACE
+)
+target_compile_options(classicladder
+        PRIVATE
+        -Wno-deprecated-declarations
+)
 get_uspace_config(classicladder)
 
-endif(USE_GTK2)
+set(CLASSICLADDER_RT_SOURCES
+        arithm_eval.c
+        arrays.c
+        calc.c
+        calc_sequential.c
+        manager.c
+        module_hal.c
+        symbols.c
+        vars_access.c
+)
+add_library(classicladder_rt SHARED ${CLASSICLADDER_RT_SOURCES})
+target_link_libraries(classicladder_rt
+        PRIVATE
+        hal
+        ulapi
+        Threads::Threads
+)
+set_target_properties(classicladder_rt
+        PROPERTIES
+        PREFIX ""
+        LIBRARY_OUTPUT_DIRECTORY ${RTLIB_DIR}
+)
+target_compile_definitions(classicladder_rt
+        PRIVATE
+        MODULE
+        RTAPI
+)

--- a/src/hal/components/CMakeLists.txt
+++ b/src/hal/components/CMakeLists.txt
@@ -25,18 +25,6 @@ build_component(NAME sampler SOURCES sampler.c LIBS ulapi hal)
 
 #todo: userkfuncs
 
-build_component(NAME classicladder_rt SOURCES
-		../classicladder/module_hal.c
-		../classicladder/arithm_eval.c
-		../classicladder/arrays.c
-		../classicladder/calc.c
-		../classicladder/calc_sequential.c
-		../classicladder/manager.c
-		../classicladder/symbols.c
-		../classicladder/vars_access.c
-		LIBS ulapi hal
-		)
-
 compile_component(abs_s32 abs_s32.comp ON)
 compile_component(abs abs.comp ON)
 compile_component(and2 and2.comp ON)

--- a/src/libnml/linklist/CMakeLists.txt
+++ b/src/libnml/linklist/CMakeLists.txt
@@ -3,3 +3,4 @@ add_library(libnml_linklist
         )
 
 target_include_directories(libnml_linklist PUBLIC .)
+set_target_properties(libnml_linklist PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Copy of the longest commit messages:

ClassicLadder: Update the configuration

This also moves the RT target from 'hal/components/CMakeLists.txt'.
Easier to handle the source files when they are in the same place.
Several of the compiler definitions that was only useful to
ClassicLadder has been moved to this CMakeList, less pollution for
all the other targets that's being built.

The source code has also moved to GTK3.

Not sure if you agree with this one, but I believe that having the configuration located in the same file makes things a lot easier.

---
Compile linklist with fPIC
Needed since it is used in  other libraries with PIC.

Should this really be a separate library? it wasn't that before. To me this almost invites other people to include it in their projects. which I believe should be avoided.

---
Add function to build Python binaries

There is one TODO in this file, we use 'sed' to update the shebang line,
I'm not sure if this is needed. Looking at the Git history, it's been
around for over 15 years.

With GNU Autoconf the shebang lines will have both the major and minor
Python version:
```python
#!/usr/bin/python3.11
```
With the current command in CMake:
```python
#!/usr/bin/python3
```
